### PR TITLE
Fix Halite::Request#domain

### DIFF
--- a/spec/halite/request_spec.cr
+++ b/spec/halite/request_spec.cr
@@ -34,4 +34,16 @@ describe Halite::Request do
   it "sets given headers" do
     request.headers["Accept"].should eq "text/html"
   end
+
+  describe "#domain" do
+    it "return `URI` with the scheme, user, password, port and host combined" do
+      request.domain.to_s.should eq "http://example.com"
+    end
+
+    context "when subdomain and path are the same" do
+      it "return `URI` with the scheme, user, password, port and host combined" do
+        Halite::Request.new("get", "https://login.example.com/login").domain.to_s.should eq "https://login.example.com"
+      end
+    end
+  end
 end

--- a/src/halite/request.cr
+++ b/src/halite/request.cr
@@ -45,11 +45,7 @@ module Halite
 
     # @return `URI` with the scheme, user, password, port and host combined
     def domain
-      domain = @uri.to_s
-      domain = domain.sub(@uri.full_path, "") if @uri.full_path != "/"
-      domain = domain.sub("##{@uri.fragment}", "") if @uri.fragment
-
-      URI.parse(domain)
+      URI.new(@uri.scheme, @uri.host, @uri.port, nil, nil, @uri.user, @uri.password, nil, @uri.opaque)
     end
 
     # @return `String` with the path, query and fragment combined


### PR DESCRIPTION
There is a bug in https://github.com/icyleaf/halite/blob/master/src/halite/request.cr#L49 when the full_path and the subdomain are the same

***BEFORE***
```crystal
Halite::Request.new("get", "https://login.example.com/login").domain
  #=> "https://.example.com"
```

***AFTER***
```crystal
Halite::Request.new("get", "https://login.example.com/login").domain
  #=> "https://login.example.com"
```