### PR TITLE
Refactor logger system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-> TODO
+### Changed
+
+- New logger system, see [#19](https://github.com/icyleaf/halite/pull/19).
 
 ## [0.4.0] (2018-06-27)
 

--- a/spec/halite/logger_spec.cr
+++ b/spec/halite/logger_spec.cr
@@ -1,0 +1,25 @@
+require "../spec_helper"
+
+private class SimpleLogger < Halite::Logger::Adapter
+  def request(request)
+    @writer.info "request"
+  end
+
+  def response(response)
+    @writer.info "response"
+  end
+end
+
+describe Halite::Logger do
+  it "should register an adapter" do
+    Halite::Logger["simple"]?.should be_nil
+
+    Halite::Logger.register_adapter "simple", SimpleLogger.new
+    Halite::Logger["simple"].should be_a SimpleLogger
+
+    Halite::Logger.adapter_names.should eq ["common", "json", "simple"]
+
+    Halite::Logger.clear
+    Halite::Logger.adapter_names.size.should eq 0
+  end
+end

--- a/spec/halite/logger_spec.cr
+++ b/spec/halite/logger_spec.cr
@@ -17,9 +17,13 @@ describe Halite::Logger do
     Halite::Logger.register_adapter "simple", SimpleLogger.new
     Halite::Logger["simple"].should be_a SimpleLogger
 
-    Halite::Logger.adapter_names.should eq ["common", "json", "simple"]
+    Halite::Logger.availables.should eq ["common", "json", "simple"]
+  end
 
-    Halite::Logger.clear
-    Halite::Logger.adapter_names.size.should eq 0
+  it "should overwrite exists adapter" do
+    Halite::Logger.register_adapter "common", SimpleLogger.new
+
+    Halite::Logger["common"].should be_a SimpleLogger
+    Halite::Logger["common"].should_not be_a Halite::Logger::Common
   end
 end

--- a/spec/halite/mime_tyupe_spec.cr
+++ b/spec/halite/mime_tyupe_spec.cr
@@ -1,0 +1,31 @@
+require "../spec_helper"
+require "yaml"
+
+private class YAMLAdapter < Halite::MimeTypes::Adapter
+  def decode(string)
+    YAML.parse string
+  end
+
+  def encode(obj)
+    obj.to_yaml
+  end
+end
+
+describe Halite::MimeTypes do
+  it "should register an adapter" do
+    Halite::MimeTypes["yaml"]?.should be_nil
+    Halite::MimeTypes["yml"]?.should be_nil
+
+    Halite::MimeTypes.register_adapter "application/x-yaml", YAMLAdapter.new
+    Halite::MimeTypes.register_alias "application/x-yaml", "yaml"
+    Halite::MimeTypes.register_alias "application/x-yaml", "yml"
+
+    Halite::MimeTypes["yaml"].should be_a YAMLAdapter
+    Halite::MimeTypes["yml"].should be_a YAMLAdapter
+
+    Halite::MimeTypes.clear
+    Halite::MimeTypes["yaml"]?.should be_nil
+    Halite::MimeTypes["yml"]?.should be_nil
+    Halite::MimeTypes["json"]?.should be_nil
+  end
+end

--- a/spec/halite/mime_tyupe_spec.cr
+++ b/spec/halite/mime_tyupe_spec.cr
@@ -22,10 +22,13 @@ describe Halite::MimeTypes do
 
     Halite::MimeTypes["yaml"].should be_a YAMLAdapter
     Halite::MimeTypes["yml"].should be_a YAMLAdapter
+  end
 
-    Halite::MimeTypes.clear
-    Halite::MimeTypes["yaml"]?.should be_nil
-    Halite::MimeTypes["yml"]?.should be_nil
-    Halite::MimeTypes["json"]?.should be_nil
+  it "should overwrite exists adapter" do
+    Halite::MimeTypes.register_adapter "application/json", YAMLAdapter.new
+    Halite::MimeTypes.register_alias "application/json", "json"
+
+    Halite::MimeTypes["json"].should be_a YAMLAdapter
+    Halite::MimeTypes["json"].should_not be_a Halite::MimeTypes::JSON
   end
 end

--- a/src/halite/logger.cr
+++ b/src/halite/logger.cr
@@ -17,12 +17,8 @@ module Halite
       @@adapters[name]?
     end
 
-    def self.adapter_names
+    def self.availables
       @@adapters.keys
-    end
-
-    def self.clear
-      @@adapters.clear
     end
 
     abstract class Adapter

--- a/src/halite/logger.cr
+++ b/src/halite/logger.cr
@@ -2,29 +2,54 @@ require "logger"
 require "file_utils"
 
 module Halite
-  abstract class Logger
-    def self.new(filename : String, mode = "a")
-      file_path = File.dirname(filename)
-      if file_path != "." && !Dir.exists?(file_path)
-        FileUtils.mkdir_p(file_path)
+  module Logger
+    @@adapters = {} of String => Halite::Logger::Adapter
+
+    def self.register_adapter(name : String, adapter : Halite::Logger::Adapter)
+      @@adapters[name] = adapter
+    end
+
+    def self.[](name : String)
+      @@adapters[name]
+    end
+
+    def self.[]?(name : String)
+      @@adapters[name]?
+    end
+
+    def self.adapter_names
+      @@adapters.keys
+    end
+
+    def self.clear
+      @@adapters.clear
+    end
+
+    abstract class Adapter
+      def self.new(filename : String, mode = "a")
+        file_path = File.dirname(filename)
+        if file_path != "." && !Dir.exists?(file_path)
+          FileUtils.mkdir_p(file_path)
+        end
+
+        new(File.open(filename, mode))
       end
 
-      new(File.open(filename, mode))
-    end
+      setter writer
 
-    def initialize(@io : IO = STDOUT)
-      @logger = ::Logger.new(@io, ::Logger::DEBUG, default_formatter, "halite")
-    end
+      def initialize(@io : IO = STDOUT)
+        @writer = ::Logger.new(@io, ::Logger::DEBUG, default_formatter, "halite")
+      end
 
-    forward_missing_to @logger
+      forward_missing_to @writer
 
-    abstract def request(request : Halite::Request)
-    abstract def response(response : Halite::Response)
+      abstract def request(request : Halite::Request)
+      abstract def response(response : Halite::Response)
 
-    # return Halite logger formatter
-    def default_formatter
-      ::Logger::Formatter.new do |severity, datetime, progname, message, io|
-        io << datetime.to_s << " " << message
+      def default_formatter
+        ::Logger::Formatter.new do |severity, datetime, progname, message, io|
+          io << datetime.to_s << " " << message
+        end
       end
     end
   end

--- a/src/halite/loggers/common.cr
+++ b/src/halite/loggers/common.cr
@@ -1,15 +1,15 @@
 require "colorize"
 
-module Halite
-  class CommonLogger < Logger
+module Halite::Logger
+  class Common < Adapter
     def request(request)
       message = String.build do |io|
-        io << "| request |" << colorful_method(request.verb)
+        io << "| request  |" << colorful_method(request.verb)
         io << "| " << request.uri
         io << "\n" << request.body unless request.body.empty?
       end
 
-      @logger.info message
+      @writer.info message
     end
 
     def response(response)
@@ -22,7 +22,7 @@ module Halite
         io << "\n" << response.body unless response.body.empty? || binary_type?(content_type)
       end
 
-      @logger.debug message
+      @writer.debug message
     end
 
     protected def colorful_method(method, is_request = true)
@@ -85,3 +85,5 @@ module Halite
     end
   end
 end
+
+Halite::Logger.register_adapter "common", Halite::Logger::Common.new

--- a/src/halite/loggers/json.cr
+++ b/src/halite/loggers/json.cr
@@ -1,0 +1,67 @@
+require "json"
+
+module Halite::Logger
+  class JSON < Adapter
+    @created_at : Time? = nil
+    @request : Request? = nil
+    @response : Response? = nil
+
+    def request(request)
+      @created_at = Time.now
+      @request = Request.new(request)
+    end
+
+    def response(response)
+      @response = Response.new(response)
+      @writer.info raw
+    end
+
+    def default_formatter
+      ::Logger::Formatter.new do |severity, datetime, progname, message, io|
+        io << message
+      end
+    end
+
+    private def raw
+      {
+        "created_at" => Time::Format::RFC_3339.format(@created_at.not_nil!, 0),
+        "entry"      => {
+          "request"  => @request.not_nil!.to_h,
+          "response" => @response.not_nil!.to_h,
+        },
+      }.to_pretty_json
+    end
+
+    struct Request
+      def initialize(@request : Halite::Request)
+      end
+
+      def to_h
+        {
+          "body"      => @request.body,
+          "headers"   => @request.headers.to_h,
+          "method"    => @request.verb,
+          "url"       => @request.uri.to_s,
+          "timestamp" => Time::Format::RFC_3339.format(Time.now, 0),
+        }
+      end
+    end
+
+    struct Response
+      def initialize(@response : Halite::Response)
+      end
+
+      def to_h
+        {
+          "body"         => @response.body,
+          "header"       => @response.headers.to_h,
+          "status_code"  => @response.status_code,
+          "http_version" => @response.version,
+          "timestamp"    => Time::Format::RFC_3339.format(Time.now, 0),
+        }
+      end
+    end
+  end
+end
+
+Halite::Logger.register_adapter "json", Halite::Logger::JSON.new

--- a/src/halite/mime_type.cr
+++ b/src/halite/mime_type.cr
@@ -20,11 +20,6 @@ module Halite
       @@adapters[normalize name]?
     end
 
-    def self.clear
-      @@adapters.clear
-      @@aliases.clear
-    end
-
     private def self.normalize(name : String)
       @@aliases.fetch name, name
     end

--- a/src/halite/options.cr
+++ b/src/halite/options.cr
@@ -218,7 +218,7 @@ module Halite
     end
 
     def with_logger(adapter = "common", filename : String? = nil, mode : String? = nil, response : Bool = true)
-      adapters = Halite::Logger.adapter_names
+      adapters = Halite::Logger.availables
       raise "Not avaiable adapter: #{adapter}, avaiables in #{adapters.join(", ")}" unless adapters.includes?(adapter)
 
       io = if filename && mode

--- a/src/halite/options.cr
+++ b/src/halite/options.cr
@@ -51,7 +51,7 @@ module Halite
     property form : Hash(String, Type)
     property json : Hash(String, Type)
 
-    property logger : Halite::Logger
+    property logger : Halite::Logger::Adapter
     property logging : Bool
 
     def self.new(headers = nil, cookies = nil, params = nil, form = nil, json = nil,
@@ -88,10 +88,7 @@ module Halite
       @form = parse_form(options)
       @json = parse_json(options)
 
-      # @logger = options.fetch("logger", CommonLogger.new).as(CommonLogger)
-      # @logging = options["logging"]? ? options["logging"].as(Bool) : false
-
-      @logger = CommonLogger.new
+      @logger = Logger::Common.new
       @logging = false
     end
 
@@ -220,11 +217,23 @@ module Halite
       self
     end
 
-    def with_logger(filename : String, mode = "a", response = false)
-      with_logger(Halite::CommonLogger.new(filename, mode), response)
+    def with_logger(adapter = "common", filename : String? = nil, mode : String? = nil, response : Bool = true)
+      adapters = Halite::Logger.adapter_names
+      raise "Not avaiable adapter: #{adapter}, avaiables in #{adapters.join(", ")}" unless adapters.includes?(adapter)
+
+      io = if filename && mode
+             File.open(filename.not_nil!, mode.not_nil!)
+           else
+             STDOUT
+           end
+
+      logger = Halite::Logger[adapter]
+      logger.writer = ::Logger.new(io, logger.level, logger.formatter, logger.progname)
+
+      with_logger(logger: logger, response: response)
     end
 
-    def with_logger(logger : Halite::Logger = CommonLogger.new, response = false)
+    def with_logger(logger : Halite::Logger::Adapter = Halite::Logger::Common.new, response : Bool = true)
       @logger = logger
       @logger.level = response ? ::Logger::DEBUG : ::Logger::INFO
       @logging = true


### PR DESCRIPTION
At first, i just only want add json-formatted logger, for current logger system was not carry it, so make a little refactor same as MIME type system and add JSON-formatted logging.

- [x] refactor logger system same as MIME type system.
  - [x] register logger adapter
  - [x] rename `@logger` to `@writer` for disambiguation
  - [x] expose `@writer` to be a setter 
  - [x] JSON-formatted logging support
  - [x] remove `Halite::Logger.clear` to keep built-in adapters
- [x] use adapter both with name and instance class support!

**Before**

```crystal
class CustomLogger < Halite::Logger
  def request(request)
    @logger.info ">> | %s | %s %s" % [request.verb, request.uri, request.body]
  end

  def response(response)
    @logger.info "<< | %s | %s %s" % [response.status_code, response.uri, response.mime_type]
  end
end

Halite.logger(CustomLogger.new)
      .get("http://httpbin.org/get", params: {name: "foobar"})
```

**After**

```crystal
class CustomLogger < Halite::Logger::Adapter
  def request(request)
    @logger.info "| >> | %s | %s %s" % [request.verb, request.uri, request.body]
  end

  def response(response)
    @logger.info "| << | %s | %s %s" % [response.status_code, response.uri, response.content_type]
  end
end

Halite::Logger.register_adapter "custom", CustomLogger.new

Halite.logger(logger: CustomLogger.new)
      .get("http://httpbin.org/get", params: {name: "foobar"})
# Also register name support
Halite.logger(adapter: "custom")
      .get("http://httpbin.org/get", params: {name: "foobar"})
```