### PR TITLE
feat: request raw string support (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add request [#raw](https://github.com/icyleaf/halite/#raw-string) string support. [#20](https://github.com/icyleaf/halite/issues/20) (thanks @[wirrareka](https://github.com/wirrareka))
+
 ### Changed
 
 - New logger system, see [#19](https://github.com/icyleaf/halite/pull/19).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Build in crystal version >= `v0.25.0`, documents generated in latest commit.
 
 <!-- TOC -->
 
+- [Index](#index)
 - [Installation](#installation)
 - [Usage](#usage)
   - [Making Requests](#making-requests)
@@ -25,6 +26,7 @@ Build in crystal version >= `v0.25.0`, documents generated in latest commit.
     - [Form data](#form-data)
     - [File uploads (via form data)](#file-uploads-via-form-data)
     - [JSON data](#json-data)
+    - [Raw String](#raw-string)
   - [Passing advanced options](#passing-advanced-options)
     - [Headers](#headers)
     - [Auth](#auth)
@@ -189,6 +191,14 @@ Use the `json` argument to pass data serialized as body encoded:
 
 ```crystal
 Halite.post("http://httpbin.org/post", json: { "firstname" => "Olen", "lastname" => "Rosenbaum" })
+```
+
+#### Raw String
+
+Use the `raw` argument to pass raw string as body:
+
+```crystal
+Halite.post("http://httpbin.org/post", raw: "name=Peter+Lee&address=%23123+Happy+Ave&Language=C%2B%2B")
 ```
 
 ### Passing advanced options

--- a/spec/halite/logger_spec.cr
+++ b/spec/halite/logger_spec.cr
@@ -12,8 +12,6 @@ end
 
 describe Halite::Logger do
   it "should register an adapter" do
-    Halite::Logger["simple"]?.should be_nil
-
     Halite::Logger.register_adapter "simple", SimpleLogger.new
     Halite::Logger["simple"].should be_a SimpleLogger
 

--- a/spec/halite_spec.cr
+++ b/spec/halite_spec.cr
@@ -76,8 +76,13 @@ describe Halite do
 
   describe ".post" do
     context "loading a simple form data" do
-      it "should easy to request" do
+      it "should easy to request with form data" do
         response = Halite.post("#{server.endpoint}/form", form: {example: "testing-form"})
+        response.to_s.should contain("example: testing-form")
+      end
+
+      it "should easy to request with raw string" do
+        response = Halite.post("#{server.endpoint}/form", raw: "example=testing-form")
         response.to_s.should contain("example: testing-form")
       end
     end

--- a/src/halite/chainable.cr
+++ b/src/halite/chainable.cr
@@ -2,11 +2,22 @@ require "base64"
 
 module Halite
   module Chainable
-    {% for verb in %w(get put head post patch delete options) %}
+    {% for verb in %w(put post patch delete options) %}
       # {{ verb.id.capitalize }} a resource
       #
+      # ### Request with form data
+      #
       # ```
-      # Halite.{{ verb.id }}("http://httpbin.org/anything", params: {
+      # Halite.{{ verb.id }}("http://httpbin.org/anything", form: {
+      #   first_name: "foo",
+      #   last_name:  "bar"
+      # })
+      # ```
+      #
+      # ### Request with json data
+      #
+      # ```
+      # Halite.{{ verb.id }}("http://httpbin.org/anything", json: {
       #   first_name: "foo",
       #   last_name:  "bar"
       # })
@@ -20,13 +31,45 @@ module Halite
           "ssl" => ssl
         })
       end
+
+      # {{ verb.id.capitalize }} a resource with raw string
+      #
+      # ```
+      # Halite.{{ verb.id }}("http://httpbin.org/anything", raw: "name=Peter+Lee&address=%23123+Happy+Ave&Language=C%2B%2B")
+      # ```
+      def {{ verb.id }}(uri : String, headers : (Hash(String, _) | NamedTuple)? = nil, params : (Hash(String, _) | NamedTuple)? = nil, raw : String? = nil, ssl : OpenSSL::SSL::Context::Client? = nil) : Halite::Response
+        request({{ verb }}, uri, {
+          "headers" => headers,
+          "params" => params,
+          "raw" => raw,
+          "ssl" => ssl
+        })
+      end
+    {% end %}
+
+    {% for verb in %w(get head) %}
+      # {{ verb.id.capitalize }} a resource
+      #
+      # ```
+      # Halite.{{ verb.id }}("http://httpbin.org/anything", params: {
+      #   first_name: "foo",
+      #   last_name:  "bar"
+      # })
+      # ```
+      def {{ verb.id }}(uri : String, headers : (Hash(String, _) | NamedTuple)? = nil, params : (Hash(String, _) | NamedTuple)? = nil, ssl : OpenSSL::SSL::Context::Client? = nil) : Halite::Response
+        request({{ verb }}, uri, {
+          "headers" => headers,
+          "params" => params,
+          "ssl" => ssl
+        })
+      end
     {% end %}
 
     # Make a request with the given Basic authorization header
     #
     # ```
     # Halite.basic_auth("icyleaf", "p@ssw0rd")
-    #       .get("http://httpbin.org/get")
+    #   .get("http://httpbin.org/get")
     # ```
     #
     # See Also: [http://tools.ietf.org/html/rfc2617](http://tools.ietf.org/html/rfc2617)
@@ -38,7 +81,7 @@ module Halite
     #
     # ```
     # Halite.auth("private-token", "6abaef100b77808ceb7fe26a3bcff1d0")
-    #       .get("http://httpbin.org/get")
+    #   .get("http://httpbin.org/get")
     # ```
     def auth(value : String) : Halite::Client
       headers({"Authorization" => value})
@@ -48,7 +91,7 @@ module Halite
     #
     # ```
     # Halite.accept("application/json")
-    #       .get("http://httpbin.org/get")
+    #   .get("http://httpbin.org/get")
     # ```
     def accept(value : String) : Halite::Client
       headers({"Accept" => value})
@@ -71,7 +114,7 @@ module Halite
     #
     # ```
     # Halite.headers(content_type: "application/json", connection: "keep-alive")
-    #       .get("http://httpbin.org/get")
+    #   .get("http://httpbin.org/get")
     # ```
     def headers(**kargs) : Halite::Client
       branch(default_options.with_headers(kargs))
@@ -94,7 +137,7 @@ module Halite
     #
     # ```
     # Halite.cookies(name: "icyleaf", "gender": "male")
-    #       .get("http://httpbin.org/get")
+    #   .get("http://httpbin.org/get")
     # ```
     def cookies(**kargs) : Halite::Client
       branch(default_options.with_cookies(kargs))
@@ -105,7 +148,7 @@ module Halite
     # ```
     # cookies = HTTP::Cookies.from_headers(headers)
     # Halite.cookies(cookies)
-    #       .get("http://httpbin.org/get")
+    #   .get("http://httpbin.org/get")
     # ```
     def cookies(cookies : HTTP::Cookies) : Halite::Client
       branch(default_options.with_cookies(cookies))
@@ -120,7 +163,7 @@ module Halite
     # Halite.timeout(5.5).get("http://httpbin.org/get")
     # # Or
     # Halite.timeout(2.minutes)
-    #       .post("http://httpbin.org/post", form: {file: "file.txt"})
+    #   .post("http://httpbin.org/post", form: {file: "file.txt"})
     # ```
     def timeout(connect_and_read : Int32 | Float64 | Time::Span) : Halite::Client
       timeout(connect_and_read, connect_and_read)
@@ -133,10 +176,10 @@ module Halite
     #
     # ```
     # Halite.timeout(3, 3.minutes)
-    #       .post("http://httpbin.org/post", form: {file: "file.txt"})
+    #   .post("http://httpbin.org/post", form: {file: "file.txt"})
     # # Or
     # Halite.timeout(3.04, 64)
-    #       .get("http://httpbin.org/get")
+    #   .get("http://httpbin.org/get")
     # ```
     def timeout(connect : (Int32 | Float64 | Time::Span)?, read : (Int32 | Float64 | Time::Span)?) : Halite::Client
       branch(default_options.with_timeout(connect, read))
@@ -147,11 +190,11 @@ module Halite
     # ```
     # # Automatically following redirects.
     # Halite.follow
-    #       .get("http://httpbin.org/relative-redirect/5")
+    #   .get("http://httpbin.org/relative-redirect/5")
     #
     # # Always redirect with any request methods
     # Halite.follow(strict: false)
-    #       .get("http://httpbin.org/get")
+    #   .get("http://httpbin.org/get")
     # ```
     def follow(strict = Options::Follow::STRICT) : Halite::Client
       branch(default_options.with_follow(strict: strict))
@@ -162,11 +205,11 @@ module Halite
     # ```
     # # Max hops 3 times
     # Halite.follow(3)
-    #       .get("http://httpbin.org/relative-redirect/3")
+    #   .get("http://httpbin.org/relative-redirect/3")
     #
     # # Always redirect with any request methods
     # Halite.follow(4, strict: false)
-    #       .get("http://httpbin.org/relative-redirect/4")
+    #   .get("http://httpbin.org/relative-redirect/4")
     # ```
     def follow(hops : Int32, strict = Options::Follow::STRICT) : Halite::Client
       branch(default_options.with_follow(hops, strict))
@@ -178,7 +221,7 @@ module Halite
     #
     # ```
     # Halite.logger
-    #       .get("http://httpbin.org/get", params: {name: "foobar"})
+    #   .get("http://httpbin.org/get", params: {name: "foobar"})
     #
     # # => halite | 2017-12-13 16:41:32 | GET    | http://httpbin.org/get?name=foobar
     # # => halite | 2017-12-13 16:42:03 | 200    | http://httpbin.org/get?name=foobar | application/json | { ... }
@@ -188,7 +231,7 @@ module Halite
     #
     # ```
     # Halite.logger(response: false)
-    #       .get("http://httpbin.org/get", params: {name: "foobar"})
+    #   .get("http://httpbin.org/get", params: {name: "foobar"})
     #
     # # => halite | 2017-12-13 16:41:32 | GET    | http://httpbin.org/get?name=foobar
     # ```
@@ -212,11 +255,11 @@ module Halite
     # Halite::Logger.register_adapter "custom", CustomLogger.new
     #
     # Halite.logger(logger: CustomLogger.new)
-    #       .get("http://httpbin.org/get", params: {name: "foobar"})
+    #   .get("http://httpbin.org/get", params: {name: "foobar"})
     #
     # # Also register name support
     # Halite.logger(adapter: "custom")
-    #       .get("http://httpbin.org/get", params: {name: "foobar"})
+    #   .get("http://httpbin.org/get", params: {name: "foobar"})
     #
     # # => halite | 2017-12-13 16:40:13 >> | GET | http://httpbin.org/get?name=foobar
     # # => halite | 2017-12-13 16:40:15 << | 200 | http://httpbin.org/get?name=foobar application/json
@@ -231,21 +274,21 @@ module Halite
     #
     # ```
     # Halite.logger(adapter: "json")
-    #       .get("http://httpbin.org/get", params: {name: "foobar"})
+    #   .get("http://httpbin.org/get", params: {name: "foobar"})
     # ```
     #
     # #### create a http request and log to file
     #
     # ```
     # Halite.logger(filename: "/tmp/halite.log")
-    #       .get("http://httpbin.org/get", params: {name: "foobar"})
+    #   .get("http://httpbin.org/get", params: {name: "foobar"})
     # ```
     #
     # #### Always create new log file and store data to JSON formatted
     #
     # ```
     # Halite.logger(adapter: "json", filename: "/tmp/halite.log", mode: "w")
-    #       .get("http://httpbin.org/get", params: {name: "foobar"})
+    #   .get("http://httpbin.org/get", params: {name: "foobar"})
     # ```
     #
     # Check the log file content: **/tmp/halite.log**
@@ -257,20 +300,27 @@ module Halite
     #
     # ```
     # Halite.request("get", "http://httpbin.org/get", {
-    #   "headers" = nil,
-    #   "params" => nil,
-    #   "form" => nil,
-    #   "json" => nil
+    #   "headers" = { "user_agent" => "halite" },
+    #   "params" => { "nickname" => "foo" },
+    #   "form" => { "username" => "bar" },
     # })
     # ```
-    def request(verb : String, uri : String, options : (Hash(String, _) | NamedTuple) = {"headers" => nil, "params" => nil, "form" => nil, "json" => nil}) : Halite::Response
+    def request(verb : String, uri : String, options : (Hash(String, _) | NamedTuple)) : Halite::Response
       response = branch(options).request(verb, uri)
       DEFAULT_OPTIONS.clear!
       response
     end
 
-    # :nodoc:
-    DEFAULT_OPTIONS = Halite::Options.new
+    # Make an HTTP request with the given verb
+    #
+    # ```
+    # Halite.request("get", "http://httpbin.org/get")
+    # ```
+    def request(verb : String, uri : String) : Halite::Response
+      response = branch.request(verb, uri)
+      DEFAULT_OPTIONS.clear!
+      response
+    end
 
     private def default_options
       {% if @type.superclass %}
@@ -284,5 +334,13 @@ module Halite
     private def branch(options : Hash(String, _) | NamedTuple | Options) : Halite::Client
       Halite::Client.new(DEFAULT_OPTIONS.merge(options))
     end
+
+    # :nodoc:
+    private def branch : Halite::Client
+      Halite::Client.new(DEFAULT_OPTIONS)
+    end
+
+    # :nodoc:
+    DEFAULT_OPTIONS = Halite::Options.new
   end
 end


### PR DESCRIPTION
related to #20 

Use the `raw` argument to pass raw string as body:

```crystal
r = Halite.post("http://httpbin.org/post", raw: "name=Peter+Lee&address=%23123+Happy+Ave&Language=C%2B%2B")
r.parse
# => {"args" => {}, "data" => "{\"a\":\"n\"}", "files" => {}, "form" => {}, "headers" => {"Accept" => "*/*", "Accept-Encoding" => "gzip, deflate", "Connection" => "close", "Content-Length" => "9", "Content-Type" => "application/json", "Host" => "httpbin.org", "User-Agent" => "Halite/0.4.0"}, "json" => {"a" => "n"}, "origin" => "60.206.194.34", "url" => "http://httpbin.org/post"}
```