### PR TITLE
Refactor options to improve performance

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,15 +2,25 @@
 
 Benchmarks performed inspired from excon's benchmarking tool.
 
+## Enviroments
+
+- MacBook Pro (Retina, 15-inch, Mid 2015), 2.2 GHz Intel Core i7, 16 GB 1600 MHz DDR3.
+- Crystal 0.26.0 (llvm 6.0.1)
+- Clients
+  - cossack v0.1.4
+  - create v0.14.0
+  - halite v0.6.0
+
 ## Result
 
 ```
+Tach times: 1000
                           Tach                Total
-                       cossack              4.325ms
-                         crest             4.3342ms
-                        halite             6.2203ms
-           halite (persistent)             4.4749ms
-          built-in http client             3.9897ms (fastest)
+                       cossack             6.9514ms (fastest)
+                         crest             9.0551ms
+                        halite             7.8958ms
+           halite (persistent)             8.0661ms
+          built-in http client             7.8528ms
 ```
 
 ## Test yourself

--- a/benchmarks/shard.yml
+++ b/benchmarks/shard.yml
@@ -6,18 +6,18 @@ authors:
 
 targets:
   run_benchmark:
-    main: src/main.cr
+    main: src/run_benchmark.cr
 
 dependencies:
   cossack:
     github: crystal-community/cossack
-    version: ~> 0.1
+    version: ~> 0.1.4
   crest:
     github: mamantoha/crest
-    version: ~> 0.10.2
+    version: ~> 0.14.0
   halite:
     path: ../
 
-crystal: 0.25.0
+crystal: 0.26.0
 
 license: MIT

--- a/benchmarks/src/run_benchmark.cr
+++ b/benchmarks/src/run_benchmark.cr
@@ -1,0 +1,21 @@
+require "./support/**"
+require "./servers/**"
+
+module Servers
+  MEMBERS = [] of Hash(String, String | Proc(String, String))
+end
+
+url = run_server
+
+sleep 1
+
+Benchmark.tach(1_000) do |x|
+  Servers::MEMBERS.each do |server|
+    name = server["name"].as(String)
+    block = server["proc"].as(Proc)
+
+    x.report(name) do
+      block.call(url)
+    end
+  end
+end

--- a/benchmarks/src/support/tach_benchmark.cr
+++ b/benchmarks/src/support/tach_benchmark.cr
@@ -45,6 +45,7 @@ module Benchmark
       def report
         fastest = @results.min_by { |_, value| value }
 
+        puts "Tach times: #{@times}"
         printf "%30s %20s\n", "Tach", "Total"
         @results.each do |label, result|
           mark = label == fastest.first ? " (fastest)" : ""

--- a/spec/halite/client_spec.cr
+++ b/spec/halite/client_spec.cr
@@ -8,29 +8,13 @@ describe Halite::Client do
       client.should be_a(Halite::Client)
     end
 
-    it "should initial with Hash client" do
-      client = Halite::Client.new({
-        "headers" => {
-          user_agent: "Spec",
-        },
+    it "should initial with options" do
+      client = Halite::Client.new(headers: {
+        user_agent: "Spec",
       })
 
       client.should be_a(Halite::Client)
       client.options.headers["User-Agent"].should eq("Spec")
-    end
-
-    it "should initial with NamedTuple client" do
-      client = Halite::Client.new({
-        headers: {
-          private_token: "token",
-        },
-        connect_timeout: 1.minutes,
-      })
-
-      client.should be_a(Halite::Client)
-      client.options.headers.should be_a(HTTP::Headers)
-      client.options.headers["Private-Token"].should eq("token")
-      client.options.timeout.connect.should eq(60)
     end
 
     it "should initial with block" do

--- a/spec/halite/client_spec.cr
+++ b/spec/halite/client_spec.cr
@@ -74,7 +74,7 @@ describe Halite::Client do
       r = client.get "#{server.endpoint}/get-cookies"
       r.headers.has_key?("Set-Cookie").should be_false
       r.cookies.size.zero?.should be_true
-      JSON.parse(r.body)["foo"].should eq("bar")
+      r.parse("json").as_h["foo"].should eq("bar")
     end
   end
 end

--- a/spec/halite/options/follow_spec.cr
+++ b/spec/halite/options/follow_spec.cr
@@ -1,0 +1,32 @@
+require "../../spec_helper"
+
+describe Halite::Follow do
+  describe "#initlize" do
+    it "shoulds works" do
+      follow = Halite::Follow.new(1, false)
+      follow.hops.should eq(1)
+      follow.strict.should be_false
+    end
+
+    it "shoulds sets one argument" do
+      follow = Halite::Follow.new(1)
+      follow.hops.should eq(1)
+      follow.strict.should be_true
+
+      follow = Halite::Follow.new(strict: false)
+      follow.hops.should eq(0)
+      follow.strict.should be_false
+    end
+  end
+
+  describe "setter" do
+    it "should works" do
+      follow = Halite::Follow.new
+      follow.hops = 3
+      follow.hops.should eq(3)
+
+      follow.strict = false
+      follow.strict.should be_false
+    end
+  end
+end

--- a/spec/halite/options/timeout_spec.cr
+++ b/spec/halite/options/timeout_spec.cr
@@ -1,0 +1,76 @@
+require "../../spec_helper"
+
+describe Halite::Timeout do
+  describe "#initlize" do
+    it "shoulds sets with Int32" do
+      timeout = Halite::Timeout.new(1, 2)
+      timeout.connect.should eq(1.0)
+      timeout.read.should eq(2)
+    end
+
+    it "shoulds sets with Float64" do
+      timeout = Halite::Timeout.new(1.2, 3.4)
+      timeout.connect.should eq(1.2)
+      timeout.read.should eq(3.4)
+    end
+
+    it "shoulds sets with Time::Span" do
+      timeout = Halite::Timeout.new(1.seconds, 1.minutes)
+      timeout.connect.should eq(1.0)
+      timeout.read.should eq(60.0)
+    end
+
+    it "shoulds sets different format" do
+      timeout = Halite::Timeout.new(1, 1.minutes)
+      timeout.connect.should eq(1.0)
+      timeout.read.should eq(60.0)
+
+      timeout = Halite::Timeout.new(1.2, 1)
+      timeout.connect.should eq(1.2)
+      timeout.read.should eq(1.0)
+    end
+
+    it "shoulds sets one argument" do
+      timeout = Halite::Timeout.new(1)
+      timeout.connect.should eq(1.0)
+      timeout.read.should be_nil
+
+      timeout = Halite::Timeout.new(connect: 2)
+      timeout.connect.should eq(2.0)
+      timeout.read.should be_nil
+
+      timeout = Halite::Timeout.new(read: 3)
+      timeout.connect.should be_nil
+      timeout.read.should eq(3.0)
+    end
+  end
+
+  describe "setter" do
+    it "should sets with Int32" do
+      timeout = Halite::Timeout.new
+      timeout.connect = 3
+      timeout.connect.should eq(3.0)
+
+      timeout.read = 12
+      timeout.read.should eq(12.0)
+    end
+
+    it "should sets with Float64" do
+      timeout = Halite::Timeout.new(1, 2)
+      timeout.connect = 3.0
+      timeout.connect.should eq(3.0)
+
+      timeout.read = 12.0
+      timeout.read.should eq(12.0)
+    end
+
+    it "should sets with Time::Span" do
+      timeout = Halite::Timeout.new(1, 2)
+      timeout.connect = 3.seconds
+      timeout.connect.should eq(3.0)
+
+      timeout.read = 1.minutes
+      timeout.read.should eq(60.0)
+    end
+  end
+end

--- a/spec/halite/options_spec.cr
+++ b/spec/halite/options_spec.cr
@@ -55,8 +55,10 @@ describe Halite::Options do
       options.json.should eq({} of String => Halite::Options::Type)
       options.raw.should be_nil
 
-      options.logger.should be_a(Halite::Logger::Common)
       options.logging?.should be_false
+      expect_raises Halite::Error, "Logging is disable now, set logging = true and try again" do
+        options.logger
+      end
     end
 
     it "should initial with Hash arguments" do
@@ -218,8 +220,10 @@ describe Halite::Options do
     options.json.should eq({} of String => Halite::Options::Type)
     options.raw.should be_nil
 
-    options.logger.should be_a(Halite::Logger::Common)
     options.logging?.should be_false
+    expect_raises Halite::Error, "Logging is disable now, set logging = true and try again" do
+      options.logger
+    end
   end
 
   describe "#with_headers" do

--- a/spec/halite/options_spec.cr
+++ b/spec/halite/options_spec.cr
@@ -22,9 +22,9 @@ private def test_options
     raw: "title=h4",
     connect_timeout: 1,
     read_timeout: 3.2,
-    ssl: OpenSSL::SSL::Context::Client.new,
     follow: 2,
-    follow_strict: false
+    follow_strict: false,
+    ssl: OpenSSL::SSL::Context::Client.new,
   )
 end
 
@@ -38,16 +38,16 @@ describe Halite::Options do
       options.cookies.should be_a(HTTP::Cookies)
       options.cookies.size.should eq(0)
 
-      options.timeout.should be_a(Halite::Options::Timeout)
+      options.timeout.should be_a(Halite::Timeout)
       options.timeout.connect.should be_nil
       options.timeout.read.should be_nil
       options.connect_timeout.should be_nil
       options.read_timeout.should be_nil
 
-      options.follow.should be_a(Halite::Options::Follow)
-      options.follow.hops.should eq(Halite::Options::Follow::DEFAULT_HOPS)
-      options.follow.strict.should eq(Halite::Options::Follow::STRICT)
-      options.follow_strict.should eq(Halite::Options::Follow::STRICT)
+      options.follow.should be_a(Halite::Follow)
+      options.follow.hops.should eq(Halite::Follow::DEFAULT_HOPS)
+      options.follow.strict.should eq(Halite::Follow::STRICT)
+      options.follow_strict.should eq(Halite::Follow::STRICT)
 
       options.ssl.should be_nil
       options.params.should eq({} of String => Halite::Options::Type)
@@ -61,13 +61,12 @@ describe Halite::Options do
       end
     end
 
-    it "should initial with Hash arguments" do
-      options = Halite::Options.new({
-        "headers" => {
+    it "should initial with original" do
+      options = Halite::Options.new(headers: {
           "private_token" => "token",
         },
-        "connect_timeout" => 3.2,
-      })
+        timeout: Halite::Timeout.new(connect: 3.2)
+      )
 
       options.should be_a(Halite::Options)
       options.headers.should be_a(HTTP::Headers)
@@ -75,34 +74,17 @@ describe Halite::Options do
       options.timeout.connect.should eq(3.2)
     end
 
-    it "should initial with NamedTuple arguments" do
-      options = Halite::Options.new({
-        headers: {
+    it "should initial with quick setup" do
+      options = Halite::Options.new(headers: {
           private_token: "token",
         },
-        connect_timeout: 1.minutes,
-      })
-
-      options.should be_a(Halite::Options)
-      options.headers.should be_a(HTTP::Headers)
-      options.headers["Private-Token"].should eq("token")
-      options.timeout.connect.should eq(60)
-    end
-
-    it "should initial with tuples arguments" do
-      options = Halite::Options.new(
-        headers: {
-          "private_token" => "token",
-        },
-        follow: 4,
-        follow_strict: false
+        connect_timeout: 1.minutes
       )
 
       options.should be_a(Halite::Options)
       options.headers.should be_a(HTTP::Headers)
       options.headers["Private-Token"].should eq("token")
-      options.follow.hops.should eq(4)
-      options.follow.strict.should eq(false)
+      options.timeout.connect.should eq(60)
     end
 
     it "should overwrite default headers" do
@@ -118,44 +100,6 @@ describe Halite::Options do
   end
 
   describe "#merge" do
-    it "should works with Hash or NamedTuple" do
-      options = test_options.merge({
-        headers: {
-          user_agent: "spec",
-        },
-        params:          {"title" => "1"},
-        form:            {"title" => "2"},
-        json:            {"title" => "3"},
-        raw:             "title=4",
-        connect_timeout: 2,
-        read_timeout:    1,
-        follow:          1,
-        follow_strict:   true,
-      })
-
-      options.headers.should eq(HTTP::Headers{"User-Agent" => "spec", "Accept" => "*/*", "Connection" => "keep-alive"})
-
-      options.cookies.should be_a(HTTP::Cookies)
-      options.cookies.size.should eq(0)
-
-      options.timeout.should be_a(Halite::Options::Timeout)
-      options.timeout.connect.should eq(2)
-      options.timeout.read.should eq(1)
-      options.connect_timeout.should eq(2)
-      options.read_timeout.should eq(1)
-
-      options.follow.should be_a(Halite::Options::Follow)
-      options.follow.hops.should eq(1)
-      options.follow.strict.should be_true
-      options.follow_strict.should be_true
-
-      options.params.should eq({"title" => "1"})
-      options.form.should eq({"title" => "2"})
-      options.json.should eq({"title" => "3"})
-      options.raw.should_not be_nil
-      options.raw.not_nil!.should eq("title=4")
-    end
-
     it "should works with Halite::Options" do
       options = test_options.merge(Halite::Options.new(
         headers: {
@@ -166,23 +110,17 @@ describe Halite::Options do
         json: {"title" => "3"},
         raw: "title=4",
         connect_timeout: 2,
-        read_timeout: 1,
-        follow: 1,
-        follow_strict: true
+        follow: 1
       ))
 
       options.headers.should eq(HTTP::Headers{"User-Agent" => "spec", "Accept" => "*/*", "Connection" => "keep-alive"})
-
-      options.cookies.should be_a(HTTP::Cookies)
       options.cookies.size.should eq(0)
 
-      options.timeout.should be_a(Halite::Options::Timeout)
       options.timeout.connect.should eq(2)
-      options.timeout.read.should eq(1)
+      options.timeout.read.should be_nil
       options.connect_timeout.should eq(2)
-      options.read_timeout.should eq(1)
+      options.read_timeout.should be_nil
 
-      options.follow.should be_a(Halite::Options::Follow)
       options.follow.hops.should eq(1)
       options.follow.strict.should be_true
       options.follow_strict.should be_true
@@ -203,16 +141,16 @@ describe Halite::Options do
     options.cookies.should be_a(HTTP::Cookies)
     options.cookies.size.should eq(0)
 
-    options.timeout.should be_a(Halite::Options::Timeout)
+    options.timeout.should be_a(Halite::Timeout)
     options.timeout.connect.should be_nil
     options.timeout.read.should be_nil
     options.connect_timeout.should be_nil
     options.read_timeout.should be_nil
 
-    options.follow.should be_a(Halite::Options::Follow)
-    options.follow.hops.should eq(Halite::Options::Follow::DEFAULT_HOPS)
-    options.follow.strict.should eq(Halite::Options::Follow::STRICT)
-    options.follow_strict.should eq(Halite::Options::Follow::STRICT)
+    options.follow.should be_a(Halite::Follow)
+    options.follow.hops.should eq(Halite::Follow::DEFAULT_HOPS)
+    options.follow.strict.should eq(Halite::Follow::STRICT)
+    options.follow_strict.should eq(Halite::Follow::STRICT)
 
     options.ssl.should be_nil
     options.params.should eq({} of String => Halite::Options::Type)
@@ -238,10 +176,8 @@ describe Halite::Options do
     end
 
     it "should overwrite NamedTuped headers" do
-      options = Halite::Options.new({
-        headers: {
-          private_token: "token",
-        },
+      options = Halite::Options.new(headers: {
+        private_token: "token",
       })
       options = options.with_headers(private_token: "new", accept: "application/json")
 
@@ -250,10 +186,8 @@ describe Halite::Options do
     end
 
     it "should overwrite Hash headers" do
-      options = Halite::Options.new({
-        "headers" => {
-          private_token: "token",
-        },
+      options = Halite::Options.new(headers: {
+        private_token: "token",
       })
       options = options.with_headers(private_token: "new", accept: "application/json")
 
@@ -293,7 +227,7 @@ describe Halite::Options do
 
   describe "#with_timeout" do
     it "should overwrite timeout" do
-      options = Halite::Options.new(connect_timeout: 1, read_timeout: 3)
+      options = Halite::Options.new(timeout: Halite::Timeout.new(connect: 1, read: 3))
       options = options.with_timeout(read: 4.minutes, connect: 1.2)
 
       options.timeout.connect.should eq(1.2)
@@ -303,7 +237,7 @@ describe Halite::Options do
 
   describe "#with_follow" do
     it "should overwrite follow" do
-      options = Halite::Options.new(follow: 1, follow_strict: true)
+      options = Halite::Options.new(follow: Halite::Follow.new(1, true))
       options = options.with_follow(follow: 5, strict: false)
 
       options.follow.hops.should eq(5)
@@ -346,10 +280,8 @@ describe Halite::Options do
         params: {"name" => "foo"},
         form: {"name" => "foo"},
         json: {"name" => "foo"},
-        connect_timeout: 1,
-        read_timeout: 3,
-        follow: 4,
-        follow_strict: false
+        timeout: Halite::Timeout.new(1, 3),
+        follow: Halite::Follow.new(4, false),
       )
       options.clear!
 
@@ -362,15 +294,15 @@ describe Halite::Options do
       options.timeout.connect.nil?.should eq(true)
       options.timeout.read.nil?.should eq(true)
 
-      options.follow.hops.should eq(Halite::Options::Follow::DEFAULT_HOPS)
-      options.follow.strict.should eq(Halite::Options::Follow::STRICT)
+      options.follow.hops.should eq(Halite::Follow::DEFAULT_HOPS)
+      options.follow.strict.should eq(Halite::Follow::STRICT)
     end
   end
 
   describe "alias methods" do
     context "read_timeout alias to timeout.read" do
       it "getter" do
-        options = Halite::Options.new(read_timeout: 34)
+        options = Halite::Options.new(timeout: Halite::Timeout.new(read: 34))
         options.read_timeout.should eq(34)
         options.timeout.read.should eq(34)
       end
@@ -390,7 +322,7 @@ describe Halite::Options do
 
     context "connect_timeout alias to timeout.connect" do
       it "getter" do
-        options = Halite::Options.new(connect_timeout: 34)
+        options = Halite::Options.new(timeout: Halite::Timeout.new(connect: 34))
         options.timeout.connect.should eq(34)
         options.connect_timeout.should eq(34)
       end
@@ -417,7 +349,7 @@ describe Halite::Options do
       end
 
       it "getter" do
-        options = Halite::Options.new(follow: 3)
+        options = Halite::Options.new(follow: Halite::Follow.new(3))
 
         # Can not return integer with follow
         options.follow.hops.should eq(3)
@@ -436,7 +368,7 @@ describe Halite::Options do
       end
 
       it "getter" do
-        options = Halite::Options.new(follow_strict: false)
+        options = Halite::Options.new(follow: Halite::Follow.new(strict: false))
 
         options.follow_strict.should eq(false)
         options.follow.strict.should eq(false)

--- a/src/halite/chainable.cr
+++ b/src/halite/chainable.cr
@@ -28,21 +28,14 @@ module Halite
       # ```
       # Halite.{{ verb.id }}("http://httpbin.org/anything", raw: "name=Peter+Lee&address=%23123+Happy+Ave&Language=C%2B%2B")
       # ```
-      def {{ verb.id }}(uri : String,
+      def {{ verb.id }}(uri : String, *,
                         headers : (Hash(String, _) | NamedTuple)? = nil,
                         params : (Hash(String, _) | NamedTuple)? = nil,
                         form : (Hash(String, _) | NamedTuple)? = nil,
                         json : (Hash(String, _) | NamedTuple)? = nil,
                         raw : String? = nil,
                         ssl : OpenSSL::SSL::Context::Client? = nil) : Halite::Response
-        request({{ verb }}, uri, {
-          "headers" => headers,
-          "params" => params,
-          "form" => form,
-          "json" => json,
-          "raw" => raw,
-          "ssl" => ssl
-        })
+        request({{ verb }}, uri, options_with(headers, params, form, json, raw, ssl))
       end
     {% end %}
 
@@ -55,17 +48,12 @@ module Halite
       #   last_name:  "bar"
       # })
       # ```
-      def {{ verb.id }}(uri : String,
+      def {{ verb.id }}(uri : String, *,
                         headers : (Hash(String, _) | NamedTuple)? = nil,
                         params : (Hash(String, _) | NamedTuple)? = nil,
                         raw : String? = nil,
                         ssl : OpenSSL::SSL::Context::Client? = nil) : Halite::Response
-        request({{ verb }}, uri, {
-          "headers" => headers,
-          "params" => params,
-          "raw" => raw,
-          "ssl" => ssl
-        })
+        request({{ verb }}, uri, options_with(headers, params, raw: raw, ssl: ssl))
       end
     {% end %}
 
@@ -200,7 +188,7 @@ module Halite
     # Halite.follow(strict: false)
     #   .get("http://httpbin.org/get")
     # ```
-    def follow(strict = Options::Follow::STRICT) : Halite::Client
+    def follow(strict = Follow::STRICT) : Halite::Client
       branch(default_options.with_follow(strict: strict))
     end
 
@@ -215,7 +203,7 @@ module Halite
     # Halite.follow(4, strict: false)
     #   .get("http://httpbin.org/relative-redirect/4")
     # ```
-    def follow(hops : Int32, strict = Options::Follow::STRICT) : Halite::Client
+    def follow(hops : Int32, strict = Follow::STRICT) : Halite::Client
       branch(default_options.with_follow(hops, strict))
     end
 
@@ -330,6 +318,16 @@ module Halite
 
     private def branch : Halite::Client
       Halite::Client.new(DEFAULT_OPTIONS)
+    end
+
+    private def options_with(headers : (Hash(String, _) | NamedTuple)? = nil,
+                             params : (Hash(String, _) | NamedTuple)? = nil,
+                             form : (Hash(String, _) | NamedTuple)? = nil,
+                             json : (Hash(String, _) | NamedTuple)? = nil,
+                             raw : String? = nil,
+                             ssl : OpenSSL::SSL::Context::Client? = nil)
+      Halite::Options.new(headers: headers, params: params,
+        form: form, json: json, raw: raw, ssl: ssl)
     end
 
     # :nodoc:

--- a/src/halite/chainable.cr
+++ b/src/halite/chainable.cr
@@ -22,25 +22,24 @@ module Halite
       #   last_name:  "bar"
       # })
       # ```
-      def {{ verb.id }}(uri : String, headers : (Hash(String, _) | NamedTuple)? = nil, params : (Hash(String, _) | NamedTuple)? = nil, form : (Hash(String, _) | NamedTuple)? = nil, json : (Hash(String, _) | NamedTuple)? = nil, ssl : OpenSSL::SSL::Context::Client? = nil) : Halite::Response
+      #
+      # ### Request with raw string
+      #
+      # ```
+      # Halite.{{ verb.id }}("http://httpbin.org/anything", raw: "name=Peter+Lee&address=%23123+Happy+Ave&Language=C%2B%2B")
+      # ```
+      def {{ verb.id }}(uri : String,
+                        headers : (Hash(String, _) | NamedTuple)? = nil,
+                        params : (Hash(String, _) | NamedTuple)? = nil,
+                        form : (Hash(String, _) | NamedTuple)? = nil,
+                        json : (Hash(String, _) | NamedTuple)? = nil,
+                        raw : String? = nil,
+                        ssl : OpenSSL::SSL::Context::Client? = nil) : Halite::Response
         request({{ verb }}, uri, {
           "headers" => headers,
           "params" => params,
           "form" => form,
           "json" => json,
-          "ssl" => ssl
-        })
-      end
-
-      # {{ verb.id.capitalize }} a resource with raw string
-      #
-      # ```
-      # Halite.{{ verb.id }}("http://httpbin.org/anything", raw: "name=Peter+Lee&address=%23123+Happy+Ave&Language=C%2B%2B")
-      # ```
-      def {{ verb.id }}(uri : String, headers : (Hash(String, _) | NamedTuple)? = nil, params : (Hash(String, _) | NamedTuple)? = nil, raw : String? = nil, ssl : OpenSSL::SSL::Context::Client? = nil) : Halite::Response
-        request({{ verb }}, uri, {
-          "headers" => headers,
-          "params" => params,
           "raw" => raw,
           "ssl" => ssl
         })
@@ -56,10 +55,15 @@ module Halite
       #   last_name:  "bar"
       # })
       # ```
-      def {{ verb.id }}(uri : String, headers : (Hash(String, _) | NamedTuple)? = nil, params : (Hash(String, _) | NamedTuple)? = nil, ssl : OpenSSL::SSL::Context::Client? = nil) : Halite::Response
+      def {{ verb.id }}(uri : String,
+                        headers : (Hash(String, _) | NamedTuple)? = nil,
+                        params : (Hash(String, _) | NamedTuple)? = nil,
+                        raw : String? = nil,
+                        ssl : OpenSSL::SSL::Context::Client? = nil) : Halite::Response
         request({{ verb }}, uri, {
           "headers" => headers,
           "params" => params,
+          "raw" => raw,
           "ssl" => ssl
         })
       end

--- a/src/halite/chainable.cr
+++ b/src/halite/chainable.cr
@@ -309,19 +309,9 @@ module Halite
     #   "form" => { "username" => "bar" },
     # })
     # ```
-    def request(verb : String, uri : String, options : (Hash(String, _) | NamedTuple)) : Halite::Response
-      response = branch(options).request(verb, uri)
-      DEFAULT_OPTIONS.clear!
-      response
-    end
-
-    # Make an HTTP request with the given verb
-    #
-    # ```
-    # Halite.request("get", "http://httpbin.org/get")
-    # ```
-    def request(verb : String, uri : String) : Halite::Response
-      response = branch.request(verb, uri)
+    def request(verb : String, uri : String, options : (Hash(String, _) | NamedTuple | Options)? = nil) : Halite::Response
+      client = options ? branch(options) : branch
+      response = client.request(verb, uri)
       DEFAULT_OPTIONS.clear!
       response
     end
@@ -334,12 +324,10 @@ module Halite
       {% end %}
     end
 
-    # :nodoc:
     private def branch(options : Hash(String, _) | NamedTuple | Options) : Halite::Client
       Halite::Client.new(DEFAULT_OPTIONS.merge(options))
     end
 
-    # :nodoc:
     private def branch : Halite::Client
       Halite::Client.new(DEFAULT_OPTIONS)
     end

--- a/src/halite/client.cr
+++ b/src/halite/client.cr
@@ -13,13 +13,10 @@ module Halite
   # ### Simple setup
   #
   # ```
-  # options = Optionns.new({
-  #   "headers" = {
-  #     "private-token" => "bdf39d82661358f80b31b67e6f89fee4"
-  #   }
+  # client = Halite::Client.new(headers: {
+  #   "private-token" => "bdf39d82661358f80b31b67e6f89fee4"
   # })
   #
-  # client = Halite::Client.new(options)
   # client.auth(private_token: "bdf39d82661358f80b31b67e6f89fee4").
   #       .get("http://httpbin.org/get", params: {
   #         name: "icyleaf"
@@ -45,14 +42,24 @@ module Halite
     # Instance a new client
     #
     # ```
-    # Halite::Client.new({
-    #   "headers" => {
-    #     "private-token" => "bdf39d82661358f80b31b67e6f89fee4",
-    #   },
-    # })
+    # Halite::Client.new(headers: {"private-token" => "bdf39d82661358f80b31b67e6f89fee4"})
     # ```
-    def self.new(options : (Hash(Options::Type, _) | NamedTuple))
-      Client.new(Options.new(options))
+    def self.new(*,
+                 headers : (Hash(String, _) | NamedTuple)? = nil,
+                 cookies : (Hash(String, _) | NamedTuple)? = nil,
+                 params : (Hash(String, _) | NamedTuple)? = nil,
+                 form : (Hash(String, _) | NamedTuple)? = nil,
+                 json : (Hash(String, _) | NamedTuple)? = nil,
+                 raw : String? = nil,
+                 timeout = Timeout.new,
+                 follow = Follow.new,
+                 ssl : OpenSSL::SSL::Context::Client? = nil,
+                 logging = false,
+                 logger = nil)
+      Client.new(Options.new(headers: headers, cookies: cookies, params: params,
+        form: form, json: json, raw: raw, ssl: ssl,
+        timeout: timeout, follow: follow,
+        logging: logging, logger: logger))
     end
 
     # Instance a new client with block
@@ -65,10 +72,8 @@ module Halite
     # Instance a new client
     #
     # ```
-    # options = Halite::Options.new({
-    #   "headers" => {
-    #     "private-token" => "bdf39d82661358f80b31b67e6f89fee4",
-    #   },
+    # options = Halite::Options.new(headers: {
+    #   "private-token" => "bdf39d82661358f80b31b67e6f89fee4"
     # })
     #
     # client = Halite::Client.new(options)
@@ -78,7 +83,7 @@ module Halite
     end
 
     # Make an HTTP request
-    def request(verb : String, uri : String, options : (Hash(String, _) | NamedTuple)? = nil) : Halite::Response
+    def request(verb : String, uri : String, options : Options? = nil) : Halite::Response
       opts = options ? @options.merge(options.not_nil!) : @options
 
       uri = make_request_uri(uri, opts)
@@ -164,7 +169,6 @@ module Halite
 
     private def merge_option_from_response(options : Halite::Options, response : Halite::Response) : Halite::Options
       return options unless response.headers
-
       # Store cookies for sessions use
       options.with_cookies(HTTP::Cookies.from_headers(response.headers))
     end

--- a/src/halite/error.cr
+++ b/src/halite/error.cr
@@ -1,59 +1,67 @@
 module Halite
-  # Generic error
-  class Error < Exception; end
+  module Exception
 
-  # Generic Connection error
-  class ConnectionError < Error; end
+    # Generic error
+    class Error < ::Exception; end
 
-  # Generic Request error
-  class RequestError < Error; end
+    # Generic Connection error
+    class ConnectionError < Error; end
 
-  # Generic Response error
-  class ResponseError < Error; end
+    # Generic Request error
+    class RequestError < Error; end
 
-  # The method given was not understood
-  class UnsupportedMethodError < RequestError; end
+    # Generic Response error
+    class ResponseError < Error; end
 
-  # The scheme given was not understood
-  class UnsupportedSchemeError < RequestError; end
+    # The method given was not understood
+    class UnsupportedMethodError < RequestError; end
 
-  # Requested to do something when we're in the wrong state
-  class StateError < RequestError; end
+    # The scheme given was not understood
+    class UnsupportedSchemeError < RequestError; end
 
-  # Generic Timeout error
-  class TimeoutError < RequestError; end
+    # Requested to do something when we're in the wrong state
+    class StateError < RequestError; end
 
-  # Notifies that we reached max allowed redirect hops
-  class TooManyRedirectsError < ResponseError; end
+    # Generic Timeout error
+    class TimeoutError < RequestError; end
 
-  # Notifies that following redirects got into an endless loop
-  class EndlessRedirectError < TooManyRedirectsError; end
+    # Notifies that we reached max allowed redirect hops
+    class TooManyRedirectsError < ResponseError; end
 
-  # The MIME type(adapter) given was not understood
-  class UnRegisterAdapterError < ResponseError; end
+    # Notifies that following redirects got into an endless loop
+    class EndlessRedirectError < TooManyRedirectsError; end
 
-  # Generic API error
-  class APIError < ResponseError
-    getter uri
-    getter status_code
-    getter status_message
+    # The MIME type(adapter) given was not understood
+    class UnRegisterAdapterError < ResponseError; end
 
-    def initialize(@message : String? = nil, @status_code : Int32? = nil, @uri : URI? = nil)
-      if status_code = @status_code
-        status_message = [HTTP.default_status_message_for(status_code).downcase]
-        status_message << "error"
-        status_message << "with url: #{@uri.not_nil!}" if @uri
+    # Generic API error
+    class APIError < ResponseError
+      getter uri
+      getter status_code
+      getter status_message
 
-        @message ||= "#{status_code} #{status_message.join(" ")} "
+      def initialize(@message : String? = nil, @status_code : Int32? = nil, @uri : URI? = nil)
+        if status_code = @status_code
+          status_message = [HTTP.default_status_message_for(status_code).downcase]
+          status_message << "error"
+          status_message << "with url: #{@uri.not_nil!}" if @uri
+
+          @message ||= "#{status_code} #{status_message.join(" ")} "
+        end
+
+        super(@message)
       end
-
-      super(@message)
     end
+
+    # 4XX client error
+    class ClientError < APIError; end
+
+    # 5XX server error
+    class ServerError < APIError; end
   end
 
-  # 4XX client error
-  class ClientError < APIError; end
-
-  # 5XX server error
-  class ServerError < APIError; end
+  {% for cls in Exception.constants %}
+    # :nodoc:
+    alias {{ cls.id }} = Exception::{{ cls.id }}
+  {% end %}
 end

--- a/src/halite/header_link.cr
+++ b/src/halite/header_link.cr
@@ -1,19 +1,7 @@
 module Halite
-  # HeaderLink Struct
-  struct HeaderLink
-    getter rel, target, params
-
-    def initialize(@rel : String, @target : String, @params : Hash(String, String))
-    end
-
-    def to_s(io)
-      io << target
-    end
-  end
-
-  # Header Link Parser
+  # Header link parser
   #
-  # Source: https://tools.ietf.org/html/rfc5988
+  # ref: [https://tools.ietf.org/html/rfc5988](https://tools.ietf.org/html/rfc5988)
   class HeaderLinkParser
     def self.parse(raw : String, uri : URI? = nil)
       new.parse(raw, uri)
@@ -60,6 +48,18 @@ module Halite
       end
 
       HeaderLink.new(rel, target, params)
+    end
+  end
+
+  # :nodoc:
+  struct HeaderLink
+    getter rel, target, params
+
+    def initialize(@rel : String, @target : String, @params : Hash(String, String))
+    end
+
+    def to_s(io)
+      io << target
     end
   end
 end

--- a/src/halite/options.cr
+++ b/src/halite/options.cr
@@ -266,7 +266,7 @@ module Halite
 
     # alias `merge` above
     def merge(options : Halite::Options) : Halite::Options
-      @headers.merge!(options.headers) if options.headers
+      @headers.merge!(options.headers) if options.headers != default_headers
       @cookies.fill_from_headers(@headers) if @headers
 
       if options.timeout.connect || options.timeout.read

--- a/src/halite/options.cr
+++ b/src/halite/options.cr
@@ -1,5 +1,5 @@
 require "openssl"
-
+require "./options/*"
 module Halite
   # Options class
   #
@@ -9,7 +9,7 @@ module Halite
   # o = Options.new(
   #   headers: {
   #     user_agent: "foobar"
-  #   },
+  #   }
   # }
   # o.headers.class # => HTTP::Headers
   # o.cookies.class # => HTTP::Cookies
@@ -43,8 +43,8 @@ module Halite
 
     property headers : HTTP::Headers
     property cookies : HTTP::Cookies
-    property timeout : Options::Timeout
-    property follow : Options::Follow
+    property timeout : Timeout
+    property follow : Follow
     property ssl : OpenSSL::SSL::Context::Client?
 
     property params : Hash(String, Type)
@@ -55,66 +55,65 @@ module Halite
     getter logging : Bool
     setter logger : Halite::Logger::Adapter?
 
-    def self.new(headers = nil, cookies = nil, params = nil, form = nil, json = nil, raw = nil,
+    def self.new(headers : (Hash(String, _) | NamedTuple)? = nil,
+                 cookies : (Hash(String, _) | NamedTuple)? = nil,
+                 params : (Hash(String, _) | NamedTuple)? = nil,
+                 form : (Hash(String, _) | NamedTuple)? = nil,
+                 json : (Hash(String, _) | NamedTuple)? = nil,
+                 raw : String? = nil,
                  connect_timeout : (Int32 | Float64 | Time::Span)? = nil,
                  read_timeout : (Int32 | Float64 | Time::Span)? = nil,
                  follow : Int32? = nil,
                  follow_strict : Bool? = nil,
-                 ssl : OpenSSL::SSL::Context::Client? = nil)
-      Options.new({
-        "headers"         => headers,
-        "cookies"         => cookies,
-        "params"          => params,
-        "form"            => form,
-        "json"            => json,
-        "raw"             => raw,
-        "read_timeout"    => read_timeout,
-        "connect_timeout" => connect_timeout,
-        "follow"          => follow,
-        "follow_strict"   => follow_strict,
-        "ssl"             => ssl,
-      })
+                 ssl : OpenSSL::SSL::Context::Client? = nil,
+                 logging = false,
+                 logger = nil)
+
+      timeout = Timeout.new(connect: connect_timeout, read: read_timeout)
+      follow = Follow.new(hops: follow, strict: follow_strict)
+      new(headers: headers, cookies: cookies, params: params, form: form,
+          json: json, raw: raw, timeout: timeout, follow: follow,
+          ssl: ssl, logging: logging, logger: logger)
     end
 
-    def initialize(options : (Hash(String, _) | NamedTuple)? = nil)
-      @headers = default_headers.merge!(parse_headers(options))
-      @cookies = parse_cookies(@headers)
-      @timeout = parse_timeout(options)
-      @follow = parse_follow(options)
-      @ssl = parse_ssl(options)
+    def initialize(*,
+                   headers : (Hash(String, _) | NamedTuple)? = nil,
+                   cookies : (Hash(String, _) | NamedTuple)? = nil,
+                   params : (Hash(String, _) | NamedTuple)? = nil,
+                   form : (Hash(String, _) | NamedTuple)? = nil,
+                   json : (Hash(String, _) | NamedTuple)? = nil,
+                   @raw : String? = nil,
+                   @timeout = Timeout.new,
+                   @follow = Follow.new,
+                   @ssl : OpenSSL::SSL::Context::Client? = nil,
+                   @logging = false,
+                   @logger = nil)
 
-      @params = parse_params(options)
-      @form = parse_form(options)
-      @json = parse_json(options)
-      @raw = parse_raw(options)
-
-      @logging = false
-      @logger = nil
+      @headers = default_headers.merge!(parse_headers(headers))
+      @cookies = parse_cookies(cookies)
+      @params = parse_params(params)
+      @form = parse_form(form)
+      @json = parse_json(json)
     end
 
-    # Returns `Options` self with gived headers combined.
-    def with_headers(**headers) : Halite::Options
-      @headers.merge!(parse_headers({"headers" => headers}))
-      self
+    # Alias `with_headers` method.
+    def with_headers(**with_headers) : Halite::Options
+      with_headers(with_headers)
     end
 
     # Returns `Options` self with gived headers combined.
     def with_headers(headers : Hash(String, _) | NamedTuple) : Halite::Options
-      @headers.merge!(parse_headers({"headers" => headers}))
+      @headers.merge!(parse_headers(headers))
       self
+    end
+
+    # Alias `with_cookies` method.
+    def with_cookies(**cookies) : Halite::Options
+      with_cookies(cookies)
     end
 
     # Returns `Options` self with gived cookies combined.
     def with_cookies(cookies : Hash(String, _) | NamedTuple) : Halite::Options
-      cookies.each do |key, value|
-        @cookies[key.to_s] = value.to_s
-      end
-
-      self
-    end
-
-    # Returns `Options` self with gived cookies combined.
-    def with_cookies(**cookies) : Halite::Options
       cookies.each do |key, value|
         @cookies[key.to_s] = value.to_s
       end
@@ -189,7 +188,7 @@ module Halite
     end
 
     def headers=(headers : (Hash(String, _) | NamedTuple))
-      @headers = parse_headers({"headers" => headers})
+      @headers = parse_headers(headers)
     end
 
     # Alias `Timeout.connect`
@@ -244,26 +243,6 @@ module Halite
       @logging == true
     end
 
-
-    # Returns `Options` self with the headers, params, form and json of this hash and other combined.
-    def merge(options : Hash(String, _) | NamedTuple) : Halite::Options
-      {% for attr in %w(headers params form json raw ssl) %}
-        merge_{{ attr.id }}(options)
-      {% end %}
-
-      @cookies.fill_from_headers(@headers)
-
-      if (timeout = parse_timeout(options)) && (timeout.connect || timeout.read)
-        @timeout = timeout
-      end
-
-      if (follow = parse_follow(options)) && follow.updated?
-        @follow = follow
-      end
-
-      self
-    end
-
     # alias `merge` above
     def merge(options : Halite::Options) : Halite::Options
       @headers.merge!(options.headers) if options.headers != default_headers
@@ -277,12 +256,11 @@ module Halite
         @follow = options.follow
       end
 
-      @ssl = options.ssl if options.ssl
-
       @params.merge!(options.params) if options.params
       @form.merge!(options.form) if options.form
       @json.merge!(options.json) if options.json
       @raw = options.raw if options.raw
+      @ssl = options.ssl if options.ssl
 
       self
     end
@@ -291,14 +269,13 @@ module Halite
     def clear! : Halite::Options
       @headers = default_headers
       @cookies = HTTP::Cookies.new
-      @timeout = Timeout.new
-      @follow = Follow.new
-      @ssl = nil
-
       @params = {} of String => Type
       @form = {} of String => Type
       @json = {} of String => Type
       @raw = nil
+      @timeout = Timeout.new
+      @follow = Follow.new
+      @ssl = nil
 
       self
     end
@@ -330,17 +307,30 @@ module Halite
       }
     end
 
-    private def parse_headers(options : (Hash(String, _) | NamedTuple)?) : HTTP::Headers
-      return HTTP::Headers.new unless opts = options
-
-      case headers = opts["headers"]?
+    private def parse_headers(raw : (Hash(String, _) | NamedTuple | HTTP::Headers)?) : HTTP::Headers
+      case raw
       when Hash, NamedTuple
-        HTTP::Headers.escape(headers)
+        HTTP::Headers.escape(raw)
       when HTTP::Headers
-        headers
+        raw.as(HTTP::Headers)
       else
         HTTP::Headers.new
       end
+    end
+
+    private def parse_cookies(raw : (Hash(String, _) | NamedTuple | HTTP::Cookies)?) : HTTP::Cookies
+      cookies = HTTP::Cookies.from_headers(@headers)
+      if objects = raw
+        objects.each do |key, value|
+          cookies[key] = case value
+                         when HTTP::Cookie
+                           value
+                         else
+                           value.to_s
+                         end
+        end
+      end
+      cookies
     end
 
     private def parse_cookies(headers : HTTP::Headers) : HTTP::Cookies
@@ -348,12 +338,12 @@ module Halite
     end
 
     {% for attr in %w(params form json) %}
-      private def parse_{{ attr.id }}(options : (Hash(String, _) | NamedTuple)?) : Hash(String, Halite::Options::Type)
+      private def parse_{{ attr.id }}(raw : (Hash(String, _) | NamedTuple)?) : Hash(String, Options::Type)
         new_{{ attr.id }} = {} of String => Type
-        return new_{{ attr.id }} unless opts = options
+        return new_{{ attr.id }} unless {{ attr.id }} = raw
 
-        if (data = opts[{{ attr.id.stringify }}]?) && data.responds_to?(:each)
-          data.each do |k, v|
+        if {{ attr.id }}.responds_to?(:each)
+          {{ attr.id }}.each do |k, v|
             new_{{ attr.id }}[k.to_s] =
               case v
               when Array
@@ -373,123 +363,5 @@ module Halite
         new_{{ attr.id }}
       end
     {% end %}
-
-    {% for attr in %w(headers params form json raw timeout follow ssl) %}
-        private def merge_{{ attr.id }}(options : Hash(String, _) | NamedTuple)
-        {% if attr.id == "raw".id %}
-          @{{ attr.id }} = parse_{{ attr.id }}(options)
-        {% else %}
-          if {{ attr.id }} = parse_{{ attr.id }}(options)
-            {% if attr.id == "timeout".id || attr.id == "follow".id || attr.id == "ssl".id %}
-              @{{ attr.id }} = {{ attr.id }}
-            {% else %}
-              @{{ attr.id }}.merge!({{ attr.id }})
-            {% end %}
-          end
-        {% end %}
-      end
-    {% end %}
-
-    private def parse_raw(options : (Hash(String, _) | NamedTuple)?) : String?
-      return unless opts = options
-
-      opts["raw"]?.as(String?)
-    end
-
-    private def parse_timeout(options : (Hash(String, _) | NamedTuple)?) : Timeout
-      Timeout.new(timeout_value("connect_timeout", options), timeout_value("read_timeout", options))
-    end
-
-    private def parse_follow(options : (Hash(String, _) | NamedTuple)?) : Follow
-      return Follow.new unless opts = options
-
-      hops = opts["follow"]?.as(Int32?)
-      strict = opts["follow_strict"]?.as(Bool?)
-      Follow.new(hops, strict)
-    end
-
-    private def parse_ssl(options : (Hash(String, _) | NamedTuple)?) : OpenSSL::SSL::Context::Client?
-      return unless opts = options
-
-      opts["ssl"]?.as(OpenSSL::SSL::Context::Client?)
-    end
-
-    private def timeout_value(key : String, options : (Hash(String, _) | NamedTuple)?) : Float64?
-      return unless opts = options
-
-      if timeout = opts[key]?
-        case timeout
-        when Int32, Time::Span
-          timeout.to_f
-        when Float64
-          timeout
-        end
-      end
-    end
-
-    # Timeout struct
-    struct Timeout
-      getter connect, read
-
-      def initialize(@connect : Float64? = nil, @read : Float64? = nil)
-      end
-
-      def initialize(connect : Time::Span? = nil, read : Time::Span? = nil)
-        @connect = connect.seconds
-        @read = read.seconds
-      end
-
-      def connect=(timeout : Int32 | Float64 | Time::Span)
-        @connect = timeout.to_f
-      end
-
-      def read=(timeout : Int32 | Float64 | Time::Span)
-        @read = timeout.to_f
-      end
-    end
-
-    struct Follow
-      # No follow by default
-      DEFAULT_HOPS = 0
-
-      # A maximum of 5 subsequent redirects
-      MAX_HOPS = 5
-
-      # Redirector hops policy
-      STRICT = true
-
-      getter hops : Int32
-      getter strict : Bool
-
-      @default : Bool
-
-      def initialize(hops : Int32? = nil, strict : Bool? = nil)
-        @hops = hops || DEFAULT_HOPS
-        @strict = strict.nil? ? STRICT : strict
-        @default = !(hops && strict)
-      end
-
-      def hops=(hops : Int32)
-        @default = false
-        @hops = hops
-      end
-
-      def strict=(strict : Bool)
-        @default = false
-        @strict = strict
-      end
-
-      def strict?
-        @strict == true
-      end
-
-      def default?
-        @default
-      end
-
-      def updated?
-        !@default
-      end
-    end
   end
 end

--- a/src/halite/options/follow.cr
+++ b/src/halite/options/follow.cr
@@ -1,0 +1,32 @@
+module Halite
+  class Options
+    struct Follow
+      # No follow by default
+      DEFAULT_HOPS = 0
+
+      # A maximum of 5 subsequent redirects
+      MAX_HOPS = 5
+
+      # Redirector hops policy
+      STRICT = true
+
+      property hops : Int32
+      property strict : Bool
+
+      def initialize(hops : Int32? = nil, strict : Bool? = nil)
+        @hops = hops || DEFAULT_HOPS
+        @strict = strict.nil? ? STRICT : strict
+      end
+
+      def strict?
+        @strict == true
+      end
+
+      def updated?
+        @hops != DEFAULT_HOPS || @strict != STRICT
+      end
+    end
+  end
+
+  alias Follow = Options::Follow
+end

--- a/src/halite/options/follow.cr
+++ b/src/halite/options/follow.cr
@@ -28,5 +28,6 @@ module Halite
     end
   end
 
+  # :nodoc:
   alias Follow = Options::Follow
 end

--- a/src/halite/options/timeout.cr
+++ b/src/halite/options/timeout.cr
@@ -33,5 +33,6 @@ module Halite
     end
   end
 
+  # :nodoc:
   alias Timeout = Options::Timeout
 end

--- a/src/halite/options/timeout.cr
+++ b/src/halite/options/timeout.cr
@@ -1,0 +1,37 @@
+module Halite
+  class Options
+    # Timeout struct
+    struct Timeout
+      getter connect : Float64?
+      getter read : Float64?
+
+      def initialize(connect : (Int32 | Float64 | Time::Span)? = nil, read : (Int32 | Float64 | Time::Span)? = nil)
+        @connect = timeout_value(connect)
+        @read = timeout_value(read)
+      end
+
+      def connect=(connect : (Int32 | Float64 | Time::Span)?)
+        @connect = timeout_value(connect)
+      end
+
+      def read=(read : (Int32 | Float64 | Time::Span)?)
+        @read = timeout_value(read)
+      end
+
+      private def timeout_value(value : (Int32 | Float64 | Time::Span)? = nil) : Float64?
+        case value
+        when Int32
+          value.as(Int32).to_f
+        when Float64
+          value.as(Float64)
+        when Time::Span
+          value.as(Time::Span).total_seconds.to_f
+        else
+          nil
+        end
+      end
+    end
+  end
+
+  alias Timeout = Options::Timeout
+end


### PR DESCRIPTION
As before all arguments accept `Hash` or `NamedTuple` which it hard to parse and merge to bind instance variable in `Halite::Options` class. Now it only accepts defined arguments and merge with same class.