### PR TITLE
New Interceptor to features

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,16 +492,15 @@ Let's persist some cookies across requests:
 ```crystal
 client = Halite::Client.new
 # Or configure it
-client = Halite::Client.new do |options|
-  options.headers = {
-    user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36",
-  }
+client = Halite::Client.new do
+  # Set basic auth
+  basic_auth "name", "foo"
 
   # Enable logging
-  options.logging = true
+  logging true
 
   # Set read timeout to one minute
-  options.read_timeout = 1.minutes
+  timeout(read: 1.minutes)
 end
 
 client.get("http://httpbin.org/cookies/set?private_token=6abaef100b77808ceb7fe26a3bcff1d0")
@@ -651,9 +650,10 @@ Halite.use("request_monster", label: "testing")
       .post("http://httpbin.org/post", form: {name: "foo"})
 
 # Or configure to client
-client = Halite::Client.new do |opts|
-  opts.with_features("request_monster", label: "testing")
+client = Halite::Client.new do
+  use "request_monster", label: "testing"
 end
+
 client.post("http://httpbin.org/post", form: {name: "foo"})
 
 # => testing

--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ Halite.use("request_monster", label: "testing")
 
 # Or configure to client
 client = Halite::Client.new do |opts|
-  opts.use("request_monster", label: "testing")
+  opts.with_features("request_monster", label: "testing")
 end
 client.post("http://httpbin.org/post", form: {name: "foo"})
 

--- a/spec/halite/client_spec.cr
+++ b/spec/halite/client_spec.cr
@@ -34,28 +34,37 @@ describe Halite::Client do
     end
   end
 
-  describe "#sessions" do
-    it "should store and send cookies" do
-      # Start mock server
-      server = MockServer.instance
-      spawn do
-        server.listen unless server.running?
+  describe "#request" do
+    %w[get post put delete head patch options].each do |verb|
+      it "should easy to #{verb} request" do
+        response = Halite.request(verb, SERVER.endpoint)
+        response.status_code.should eq(200)
+      end
+      it "should easy to #{verb} request with hash or namedtuple" do
+        response = Halite.request(verb, SERVER.endpoint, params: {name: "foo"})
+        response.status_code.should eq(200)
       end
 
-      # Wait server a moment
-      sleep 1
+      it "should easy to #{verb} request with options" do
+        response = Halite.request(verb, SERVER.endpoint, Halite::Options.new)
+        response.status_code.should eq(200)
+      end
+    end
+  end
 
+  describe "#sessions" do
+    it "should store and send cookies" do
       client = Halite::Client.new
 
       # get Set-Cookies from server
-      r = client.get "#{server.endpoint}/cookies"
+      r = client.get SERVER.api("cookies")
       r.headers["Set-Cookie"].should eq("foo=bar")
 
       r.cookies.size.should eq(1)
       r.cookies["foo"].value.should eq("bar")
 
       # request with stored cookies
-      r = client.get "#{server.endpoint}/get-cookies"
+      r = client.get SERVER.api("get-cookies")
       r.headers.has_key?("Set-Cookie").should be_false
       r.cookies.size.zero?.should be_true
       r.parse("json").as_h["foo"].should eq("bar")

--- a/spec/halite/client_spec.cr
+++ b/spec/halite/client_spec.cr
@@ -18,12 +18,9 @@ describe Halite::Client do
     end
 
     it "should initial with block" do
-      client = Halite::Client.new do |options|
-        options.headers = {
-          private_token: "token",
-        }
-        options.read_timeout = 2.minutes
-        options.timeout.connect = 40
+      client = Halite::Client.new do
+        headers({private_token: "token"})
+        timeout(read: 2.minutes, connect: 40)
       end
 
       client.should be_a(Halite::Client)

--- a/spec/halite/features_spec.cr
+++ b/spec/halite/features_spec.cr
@@ -1,22 +1,19 @@
 require "../spec_helper"
 
-private class NullFeature < Halite::Feature
-end
-
 describe Halite::Features do
   describe "register" do
     it "should use a registered feature" do
       Halite::Features["null"]?.should be_nil
-      Halite::Features.register "null", NullFeature
+      Halite::Features.register "null", TestFeatures::Null
       Halite::Features.availables.includes?("null").should be_true
-      Halite::Features["null"].should eq(NullFeature)
+      Halite::Features["null"].should eq(TestFeatures::Null)
     end
   end
 end
 
 describe Halite::Feature do
   it "should a empty feature" do
-    feature = NullFeature.new
+    feature = TestFeatures::Null.new
     feature.responds_to?(:request).should be_true
     feature.responds_to?(:response).should be_true
     feature.responds_to?(:intercept).should be_true

--- a/spec/halite/features_spec.cr
+++ b/spec/halite/features_spec.cr
@@ -13,3 +13,12 @@ describe Halite::Features do
     end
   end
 end
+
+describe Halite::Feature do
+  it "should a empty feature" do
+    feature = NullFeature.new
+    feature.responds_to?(:request).should be_true
+    feature.responds_to?(:response).should be_true
+    feature.responds_to?(:intercept).should be_true
+  end
+end

--- a/spec/halite/features_spec.cr
+++ b/spec/halite/features_spec.cr
@@ -4,9 +4,12 @@ private class NullFeature < Halite::Feature
 end
 
 describe Halite::Features do
-  it "should register a feature" do
-    Halite::Features["null"]?.should be_nil
-    Halite::Features.register "null", NullFeature
-    Halite::Features["null"].should eq(NullFeature)
+  describe "register" do
+    it "should use a registered feature" do
+      Halite::Features["null"]?.should be_nil
+      Halite::Features.register "null", NullFeature
+      Halite::Features.availables.includes?("null").should be_true
+      Halite::Features["null"].should eq(NullFeature)
+    end
   end
 end

--- a/spec/halite/response_spec.cr
+++ b/spec/halite/response_spec.cr
@@ -1,10 +1,10 @@
 require "../spec_helper"
 
-URL         = "http://example.com"
-STATUS_CODE = 200
-HEADERS     = {"Content-Type" => "text/plain; charset=utf-8"}
-BODY        = "hello world"
-COOKIES     = "foo=bar; domain=example.com"
+private URL         = "http://example.com"
+private STATUS_CODE = 200
+private HEADERS     = {"Content-Type" => "text/plain; charset=utf-8"}
+private BODY        = "hello world"
+private COOKIES     = "foo=bar; domain=example.com"
 
 private def response(url = URL, status_code = STATUS_CODE, headers = HEADERS, body = BODY)
   Halite::Response.new(

--- a/spec/halite_spec.cr
+++ b/spec/halite_spec.cr
@@ -1,14 +1,4 @@
 require "./spec_helper"
-require "./support/mock_server"
-
-# Start mock server
-server = MockServer.new
-spawn do
-  server.listen
-end
-
-# Wait server a moment
-sleep 1
 
 describe Halite do
   describe ".new" do
@@ -22,38 +12,38 @@ describe Halite do
   describe ".get" do
     context "loading a simple uri" do
       it "should easy to request" do
-        response = Halite.get(server.endpoint)
+        response = Halite.get(SERVER.endpoint)
         response.to_s.should match(/<!doctype html>/)
       end
     end
 
     context "with query string parameters" do
       it "should easy to request" do
-        response = Halite.get("#{server.endpoint}/params", params: {foo: "bar"})
+        response = Halite.get(SERVER.api("params"), params: {foo: "bar"})
         response.to_s.should eq("Params!")
       end
     end
 
     context "with query string parameters in the URI and opts hash" do
       it "includes both" do
-        response = Halite.get("#{server.endpoint}/multiple-params?foo=bar", params: {baz: "quux"})
+        response = Halite.get("#{SERVER.endpoint}/multiple-params?foo=bar", params: {baz: "quux"})
         response.to_s.should eq("More Params!")
       end
     end
 
     context "with headers" do
       it "is easy" do
-        response = Halite.accept("application/json").get(server.endpoint)
+        response = Halite.accept("application/json").get(SERVER.endpoint)
         response.to_s.should match(/json/)
       end
     end
 
-    #   # context "loading binary data" do
-    #   #   it "is encoded as bytes" do
-    #   #     response = Halite.get "#{server.endpoint}/bytes"
-    #   #     # response.to_s.encoding.should eq(Encoding::BINARY)
-    #   #   end
-    #   # end
+    # context "loading binary data" do
+    #   it "is encoded as bytes" do
+    #     response = Halite.get SERVER.api("bytes")
+    #     # response.to_s.encoding.should eq(Encoding::BINARY)
+    #   end
+    # end
 
     context "with a large request body" do
       [16_000, 16_500, 17_000, 34_000, 68_000].each do |size|
@@ -62,7 +52,7 @@ describe Halite do
             it "returns a large body" do
               characters = ("A".."Z").to_a
               form = Hash(String, String).new.tap { |obj| (size + fuzzer).times { |i| obj[i.to_s] = characters[i % characters.size] } }
-              response = Halite.post "#{server.endpoint}/echo-body", form: form
+              response = Halite.post SERVER.api("echo-body"), form: form
               response_body = HTTP::Params.escape(form)
 
               response.to_s.should eq(response_body)
@@ -77,19 +67,19 @@ describe Halite do
   describe ".post" do
     context "loading a simple form data" do
       it "should easy to request with form data" do
-        response = Halite.post("#{server.endpoint}/form", form: {example: "testing-form"})
+        response = Halite.post(SERVER.api("form"), form: {example: "testing-form"})
         response.to_s.should contain("example: testing-form")
       end
 
       it "should easy to request with raw string" do
-        response = Halite.post("#{server.endpoint}/form", raw: "example=testing-form")
+        response = Halite.post(SERVER.api("form"), raw: "example=testing-form")
         response.to_s.should contain("example: testing-form")
       end
     end
 
     context "uploading file" do
       it "should easy upload only file" do
-        response = Halite.post("#{server.endpoint}/upload", form: {file: File.open("./src/halite.cr")})
+        response = Halite.post(SERVER.api("upload"), form: {file: File.open("./src/halite.cr")})
         body = response.parse.as_h
         params = body["params"].as_h
         files = body["files"].as_h
@@ -102,7 +92,7 @@ describe Halite do
       end
 
       it "should easy upload file with other form data" do
-        response = Halite.post("#{server.endpoint}/upload", form: {file: File.open("./src/halite.cr"), "name": "foobar"})
+        response = Halite.post(SERVER.api("upload"), form: {file: File.open("./src/halite.cr"), "name": "foobar"})
         body = response.parse.as_h
         params = body["params"].as_h
         files = body["files"].as_h
@@ -116,7 +106,7 @@ describe Halite do
       end
 
       it "should easy upload multiple files" do
-        response = Halite.post("#{server.endpoint}/upload", form: {avatar: [File.open("halite-logo.png"), File.open("halite-logo-small.png")]})
+        response = Halite.post(SERVER.api("upload"), form: {avatar: [File.open("halite-logo.png"), File.open("halite-logo-small.png")]})
         body = response.parse.as_h
         params = body["params"].as_h
         files = body["files"].as_h
@@ -130,7 +120,7 @@ describe Halite do
       end
 
       it "should easy upload multiple files with other form data" do
-        response = Halite.post("#{server.endpoint}/upload", form: {
+        response = Halite.post(SERVER.api("upload"), form: {
           avatar: [File.open("halite-logo.png"), File.open("halite-logo-small.png")],
           name:   "foobar",
         })
@@ -153,28 +143,28 @@ describe Halite do
   describe ".follow" do
     context "with redirects" do
       it "should easy for 301 with full uri" do
-        response = Halite.follow.get("#{server.endpoint}/redirect-301")
+        response = Halite.follow.get(SERVER.api("redirect-301"))
         response.to_s.should match(/<!doctype html>/)
       end
 
       it "should easy for 301 with relative path" do
-        response = Halite.follow.get("#{server.endpoint}/redirect-301", params: {"relative_path" => true})
+        response = Halite.follow.get(SERVER.api("redirect-301"), params: {"relative_path" => true})
         response.to_s.should match(/<!doctype html>/)
       end
 
       it "should easy for 301 with relative path which is not include slash" do
-        response = Halite.follow.get("#{server.endpoint}/redirect-301", params: {"relative_path_without_slash" => true})
+        response = Halite.follow.get(SERVER.api("redirect-301"), params: {"relative_path_without_slash" => true})
         response.to_s.should eq("hello")
       end
 
       it "should easy for 302" do
-        response = Halite.follow.get("#{server.endpoint}/redirect-302")
+        response = Halite.follow.get(SERVER.api("redirect-302"))
         response.to_s.should match(/<!doctype html>/)
       end
 
       it "should store full history" do
         times = 5
-        response = Halite.follow.get("#{server.endpoint}/multi-redirect?n=#{times}")
+        response = Halite.follow.get("#{SERVER.endpoint}/multi-redirect?n=#{times}")
         response.history.class.should eq Array(Halite::Response)
         response.history.size.should eq(times + 1)
       end
@@ -183,7 +173,7 @@ describe Halite do
 
   describe ".put" do
     it "should easy to request" do
-      response = Halite.put server.endpoint
+      response = Halite.put SERVER.endpoint
       response.status_code.should eq(200)
       response.content_type.should match(/html/)
     end
@@ -191,7 +181,7 @@ describe Halite do
 
   describe ".delete" do
     it "should easy to request" do
-      response = Halite.delete server.endpoint
+      response = Halite.delete SERVER.endpoint
       response.status_code.should eq(200)
       response.content_type.should match(/html/)
     end
@@ -199,7 +189,7 @@ describe Halite do
 
   describe ".patch" do
     it "should easy to request" do
-      response = Halite.patch server.endpoint
+      response = Halite.patch SERVER.endpoint
       response.status_code.should eq(200)
       response.content_type.should match(/html/)
     end
@@ -207,7 +197,7 @@ describe Halite do
 
   describe ".head" do
     it "should easy to request" do
-      response = Halite.head server.endpoint
+      response = Halite.head SERVER.endpoint
       response.status_code.should eq(200)
       response.content_type.should match(/html/)
     end
@@ -215,7 +205,7 @@ describe Halite do
 
   describe ".options" do
     it "should easy to request" do
-      response = Halite.options server.endpoint
+      response = Halite.options SERVER.endpoint
       response.status_code.should eq(200)
       response.content_type.should match(/html/)
     end
@@ -224,14 +214,24 @@ describe Halite do
   describe ".request" do
     %w[get post put delete head patch options].each do |verb|
       it "should easy to #{verb} request" do
-        response = Halite.request(verb, server.endpoint)
+        response = Halite.request(verb, SERVER.endpoint)
+        response.status_code.should eq(200)
+      end
+
+      it "should easy to #{verb} request with hash or namedtuple" do
+        response = Halite.request(verb, SERVER.endpoint, params: {name: "foo"})
+        response.status_code.should eq(200)
+      end
+
+      it "should easy to #{verb} request with options" do
+        response = Halite.request(verb, SERVER.endpoint, Halite::Options.new)
         response.status_code.should eq(200)
       end
     end
 
     it "throws an exception with non-support method" do
       expect_raises Halite::UnsupportedMethodError do
-        Halite.request("abc", server.endpoint)
+        Halite.request("abc", SERVER.endpoint)
       end
     end
 
@@ -274,46 +274,80 @@ describe Halite do
 
   describe ".cookies" do
     it "passes correct `Cookie` header" do
-      client = Halite.cookies(abc: "def").get("#{server.endpoint}/cookies")
+      client = Halite.cookies(abc: "def").get(SERVER.api("cookies"))
       client.to_s.should eq("abc: def")
     end
 
     it "properly works with cookie jars from response" do
-      res = Halite.get("#{server.endpoint}/cookies")
-      client = Halite.cookies(res.cookies).get("#{server.endpoint}/cookies")
+      res = Halite.get(SERVER.api("cookies"))
+      client = Halite.cookies(res.cookies).get(SERVER.api("cookies"))
       client.to_s.should eq("foo: bar")
     end
 
     it "properly merges cookies" do
-      res = Halite.get("#{server.endpoint}/cookies")
+      res = Halite.get(SERVER.api("cookies"))
       client = Halite.cookies(foo: 123, bar: 321).cookies(res.cookies)
-      client.get("#{server.endpoint}/cookies").to_s.should eq("foo: bar\nbar: 321")
+      client.get(SERVER.api("cookies")).to_s.should eq("foo: bar\nbar: 321")
     end
   end
 
   describe ".use" do
-    it "sets given feature name" do
-      client = Halite.use("logger")
-      client.options.features.has_key?("logger").should be_true
-      client.options.features["logger"].should be_a(Halite::Features::Logger)
-      logger = client.options.features["logger"].as(Halite::Features::Logger)
-      logger.writer.should be_a(Halite::Features::Logger::Common)
-      logger.writer.skip_request_body.should be_false
-      logger.writer.skip_response_body.should be_false
-      logger.writer.skip_benchmark.should be_false
-      logger.writer.colorize.should be_true
+    describe "built-in features" do
+      it "sets given feature name" do
+        client = Halite.use("logger")
+        client.options.features.has_key?("logger").should be_true
+        client.options.features["logger"].should be_a(Halite::Features::Logger)
+        logger = client.options.features["logger"].as(Halite::Features::Logger)
+        logger.writer.should be_a(Halite::Features::Logger::Common)
+        logger.writer.skip_request_body.should be_false
+        logger.writer.skip_response_body.should be_false
+        logger.writer.skip_benchmark.should be_false
+        logger.writer.colorize.should be_true
+      end
+
+      it "sets given feature name and options" do
+        client = Halite.use("logger", logger: Halite::Features::Logger::JSON.new(skip_request_body: true, colorize: false))
+        client.options.features.has_key?("logger").should be_true
+        client.options.features["logger"].should be_a(Halite::Features::Logger)
+        logger = client.options.features["logger"].as(Halite::Features::Logger)
+        logger.writer.should be_a(Halite::Features::Logger::JSON)
+        logger.writer.skip_request_body.should be_true
+        logger.writer.skip_response_body.should be_false
+        logger.writer.skip_benchmark.should be_false
+        logger.writer.colorize.should be_false
+
+        # Restore
+        Colorize.on_tty_only!
+      end
     end
 
-    it "sets given feature name and options" do
-      client = Halite.use("logger", logger: Halite::Features::Logger::JSON.new(skip_request_body: true, colorize: false))
-      client.options.features.has_key?("logger").should be_true
-      client.options.features["logger"].should be_a(Halite::Features::Logger)
-      logger = client.options.features["logger"].as(Halite::Features::Logger)
-      logger.writer.should be_a(Halite::Features::Logger::JSON)
-      logger.writer.skip_request_body.should be_true
-      logger.writer.skip_response_body.should be_false
-      logger.writer.skip_benchmark.should be_false
-      logger.writer.colorize.should be_false
+    describe "custom features" do
+      it "should modify the headers of request and response" do
+        response = Halite.use("append_headers").get(SERVER.api("/anything?a=b"))
+        response.headers["X-Powered-By"].should eq("Halite")
+        response.parse.as_h["headers"]["X-API-Limit"].should eq("60")
+      end
+
+      it "should mock response with interceptor" do
+        response = Halite.use("mock").get(SERVER.api("/anything?a=b"))
+        response.status_code.should eq(400)
+        response.body.should eq("mock")
+      end
+
+      describe "enable multiple interceptors" do
+        it "should call next intercept" do
+          response = Halite.use("404").use("powered_by").get(SERVER.api("/anything?a=b"))
+          response.status_code.should eq(404)
+          response.headers["X-Powered-By"].should eq("Halite")
+          response.body.should_not eq("")
+        end
+
+        it "should return on first interceptor" do
+          response = Halite.use("mock").use("404").get(SERVER.api("/anything?a=b"))
+          response.status_code.should eq(400)
+          response.body.should eq("mock")
+        end
+      end
     end
   end
 
@@ -343,6 +377,3 @@ describe Halite do
     end
   end
 end
-
-# Clean up
-server.close

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,71 @@
 require "spec"
+require "./support/mock_server"
 require "../src/halite"
+
+module TestFeatures
+  class Null < Halite::Feature; end
+
+  class AppendHeaders < Halite::Feature
+    def request(request)
+      request.headers["X-API-Limit"] = "60"
+      request
+    end
+
+    def response(response)
+      response.headers["X-Powered-By"] = "Halite"
+      response
+    end
+
+    Halite::Features.register "append_headers", self
+  end
+end
+
+module TestInterceptors
+  class Mock < Halite::Feature
+    def intercept(chain)
+      response = Halite::Response.new(chain.request.uri, 400, "mock")
+      chain.return(response)
+    end
+
+    Halite::Features.register "mock", self
+  end
+
+  class AlwaysNotFound < Halite::Feature
+    def intercept(chain)
+      response = chain.perform
+      response = Halite::Response.new(chain.request.uri, 404, response.body, response.headers)
+      chain.next(response)
+    end
+
+    Halite::Features.register "404", self
+  end
+
+  class PoweredBy < Halite::Feature
+    def intercept(chain)
+      if response = chain.response
+        response.headers["X-Powered-By"] = "Halite"
+        chain.return(response)
+      else
+        chain
+      end
+    end
+
+    Halite::Features.register "powered_by", self
+  end
+end
+
+####################
+# Start mock server
+####################
+SERVER = MockServer.new
+spawn do
+  SERVER.listen
+end
+
+# Wait server a moment
+sleep 1.milliseconds
+
+# Close server
+at_exit do
+  SERVER.close
+end

--- a/spec/support/mock_server.cr
+++ b/spec/support/mock_server.cr
@@ -41,4 +41,8 @@ class MockServer < HTTP::Server
   def scheme
     "http"
   end
+
+  def api(path : String)
+    File.join(endpoint, path)
+  end
 end

--- a/src/halite/client.cr
+++ b/src/halite/client.cr
@@ -61,10 +61,17 @@ module Halite
     end
 
     # Instance a new client with block
+    #
+    # ```crystal
+    # client = Halite::Client.new do
+    #   basic_auth "name", "foo"
+    #   logger true
+    # end
+    # ```
     def self.new(&block)
       options = Options.new
-      yield options
-      Client.new(options)
+      instance = Client.new(options)
+      with instance yield
     end
 
     # Instance a new client

--- a/src/halite/features.cr
+++ b/src/halite/features.cr
@@ -1,21 +1,21 @@
 module Halite
   module Features
-    @@featurs = {} of String => Feature.class
+    @@features = {} of String => Feature.class
 
     def self.register(name : String, feature : Feature.class)
-      @@featurs[name] = feature
+      @@features[name] = feature
     end
 
     def self.[](name : String)
-      @@featurs[name]
+      @@features[name]
     end
 
     def self.[]?(name : String)
-      @@featurs[name]?
+      @@features[name]?
     end
 
     def self.availables
-      @@featurs.keys
+      @@features.keys
     end
   end
 
@@ -39,7 +39,14 @@ module Halite
     end
   end
 
+  # Interceptor for feature
   module Interceptor
+    # Interceptor chain
+    #
+    # Chain has two result:
+    #
+    # - next
+    # - return
     class Chain
       enum Result
         Next

--- a/src/halite/features.cr
+++ b/src/halite/features.cr
@@ -33,8 +33,6 @@ module Halite
       response
     end
 
-    # Interceptor
-    #
     # Intercept and cooking request and response
     def intercept(chain : Interceptor::Chain) : Interceptor::Chain
       chain
@@ -52,8 +50,11 @@ module Halite
       getter response
       getter result
 
+      @performed_response : Response?
+
       def initialize(@request : Request, @response : Response?, @options : Options, &block : -> Response)
         @result = Result::Next
+        @performed_response = nil
         @perform_request_block = block
       end
 
@@ -71,8 +72,13 @@ module Halite
         self
       end
 
+      def performed?
+        !@performed_response.nil?
+      end
+
       def perform
-        @perform_request_block.call
+        @performed_response ||= @perform_request_block.call
+        @performed_response.not_nil!
       end
     end
   end

--- a/src/halite/features.cr
+++ b/src/halite/features.cr
@@ -45,8 +45,8 @@ module Halite
     #
     # Chain has two result:
     #
-    # - next
-    # - return
+    # next: perform and run next interceptor
+    # return: perform and return
     class Chain
       enum Result
         Next

--- a/src/halite/features.cr
+++ b/src/halite/features.cr
@@ -23,8 +23,58 @@ module Halite
     def initialize(**options)
     end
 
-    abstract def request(request : Request) : Request
-    abstract def response(response : Response) : Response
+    # Cooks with request
+    def request(request : Request) : Request
+      request
+    end
+
+    # Cooking with response
+    def response(response : Response) : Response
+      response
+    end
+
+    # Interceptor
+    #
+    # Intercept and cooking request and response
+    def intercept(chain : Interceptor::Chain) : Interceptor::Chain
+      chain
+    end
+  end
+
+  module Interceptor
+    class Chain
+      enum Result
+        Next
+        Return
+      end
+
+      property request
+      getter response
+      getter result
+
+      def initialize(@request : Request, @response : Response?, @options : Options, &block : -> Response)
+        @result = Result::Next
+        @perform_request_block = block
+      end
+
+      def next(response)
+        @result = Result::Next
+        @response = response
+
+        self
+      end
+
+      def return(response)
+        @result = Result::Return
+        @response = response
+
+        self
+      end
+
+      def perform
+        @perform_request_block.call
+      end
+    end
   end
 end
 

--- a/src/halite/options.cr
+++ b/src/halite/options.cr
@@ -192,16 +192,6 @@ module Halite
       self
     end
 
-    # Alias to `with_features`
-    def use(*features)
-      with_features(*features)
-    end
-
-    # Alias to `with_features`
-    def use(feature : String, **opts)
-      with_features(feature, **opts)
-    end
-
     def headers=(headers : (Hash(String, _) | NamedTuple))
       @headers = parse_headers(headers)
     end

--- a/src/halite/options.cr
+++ b/src/halite/options.cr
@@ -281,6 +281,7 @@ module Halite
       @raw = nil
       @timeout = Timeout.new
       @follow = Follow.new
+      @features = {} of String => Feature
       @ssl = nil
 
       self

--- a/src/halite/options.cr
+++ b/src/halite/options.cr
@@ -249,9 +249,17 @@ module Halite
       @logging
     end
 
-    # alias `merge` above
+    # Merge with other `Options`
     def merge(options : Halite::Options) : Halite::Options
-      @headers.merge!(options.headers) if options.headers != default_headers
+      if options.headers != default_headers
+        # Remove default key to make sure it is not to overwrite new one.
+        default_headers.each do |key, value|
+          options.headers.delete(key) if options.headers[key] = default_headers[key]
+        end
+
+        @headers.merge!(options.headers)
+      end
+
       @cookies.fill_from_headers(@headers) if @headers
 
       if options.timeout.connect || options.timeout.read

--- a/src/halite/response.cr
+++ b/src/halite/response.cr
@@ -1,6 +1,13 @@
 module Halite
   class Response
+    def self.new(uri : URI, status_code : Int32, body : String? = nil, headers = HTTP::Headers.new,
+                 status_message = nil, body_io : IO? = nil, version = "HTTP/1.1", history = [] of Response)
+      conn = HTTP::Client::Response.new(status_code, body, headers, status_message, version, body_io)
+      new(uri, conn, history)
+    end
+
     getter uri
+    getter conn
     getter history : Array(Response)
 
     def initialize(@uri : URI, @conn : HTTP::Client::Response, @history = [] of Response)


### PR DESCRIPTION
Now you can intercept each request and return any response without starting the real http request. of cause you also can performing the HTTP request, after then cook and return.

For example:

Creating a simple mock feature:

```crystal
class Mock < Halite::Feature
  def intercept(chain)
    response = Halite::Response.new(chain.request.uri, 400, "[]")
    chain.return(response)
  end

  Halite::Features.register "mock", self
end

r = Halite.use("mock").get("http://httpbin.org/anything")
r.status_code    # => 400
r.body           # => []
```

`chain` is a `Halite::Interceptor::Chain` class which has two result: 

- `next`: perform and run next interceptor
- `return`: perform and return

So, you can intercept and turn to the following registered features. 

```crystal
class AlwaysNotFound < Halite::Feature
  def intercept(chain)
    response = chain.perform
    response = Halite::Response.new(chain.request.uri, 404, response.body, response.headers)
    chain.next(response)
  end

  Halite::Features.register "404", self
end

class PoweredBy < Halite::Feature
  def intercept(chain)
    if response = chain.response
      response.headers["X-Powered-By"] = "Halite"
      chain.return(response)
    else
      chain
    end
  end

  Halite::Features.register "powered_by", self
end

r = Halite.use("404").use("powered_by").get("http://httpbin.org/user-agent")
r.status_code               # => 404
r.headers["X-Powered-By"]   # => Halite
r.body                      # => {"user-agent":"Halite/0.6.0"}
```