### PR TITLE
Fix history works with follow(redirects) only

### DIFF
--- a/spec/halite_spec.cr
+++ b/spec/halite_spec.cr
@@ -141,24 +141,41 @@ describe Halite do
   end
 
   describe ".follow" do
+    context "without redirects" do
+      it "should return empty history" do
+        response = Halite.get(SERVER.api("/"))
+        response.history.size.should eq(0)
+      end
+    end
+
     context "with redirects" do
+      it "should return one history with non-redirect url" do
+        response = Halite.follow.get(SERVER.api("/"))
+        response.history.size.should eq(1)
+        response.to_s.should match(/<!doctype html>/)
+      end
+
       it "should easy for 301 with full uri" do
         response = Halite.follow.get(SERVER.api("redirect-301"))
+        response.history.size.should eq(2)
         response.to_s.should match(/<!doctype html>/)
       end
 
       it "should easy for 301 with relative path" do
         response = Halite.follow.get(SERVER.api("redirect-301"), params: {"relative_path" => true})
+        response.history.size.should eq(2)
         response.to_s.should match(/<!doctype html>/)
       end
 
       it "should easy for 301 with relative path which is not include slash" do
         response = Halite.follow.get(SERVER.api("redirect-301"), params: {"relative_path_without_slash" => true})
+        response.history.size.should eq(2)
         response.to_s.should eq("hello")
       end
 
       it "should easy for 302" do
         response = Halite.follow.get(SERVER.api("redirect-302"))
+        response.history.size.should eq(2)
         response.to_s.should match(/<!doctype html>/)
       end
 

--- a/src/halite/client.cr
+++ b/src/halite/client.cr
@@ -137,8 +137,8 @@ module Halite
         feature.response(res)
       end
 
-      # Append history of response
-      @history << response
+      # Append history of response if enable follow
+      @history << response unless options.follow.hops.zero?
 
       # Merge headers and cookies from response
       @options = merge_option_from_response(options, response)


### PR DESCRIPTION
`#history` was design works with `#follow` (redirects) only, by default it return empty array.

You can  use `#follow` to store history(at least one history)

```crystal
r = Halite.get "http://httpbin.org/get"
r.history # => []

r = Halite.follow.get "http://httpbin.org/get"
r.history.size # => 1
r.history      # => [#<Halite::Response HTTP/1.1 200 OK { ... }]

r = Halite.follow.get "http://httpbin.org/redirect/2"
r.history.size # => 3
r.history      # => [#<Halite::Response HTTP/1.1 302 FOUND {"Location" => "/relative-redirect/2" ...>,
#                    #<Halite::Response HTTP/1.1 302 FOUND {"Location" => "/relative-redirect/1" ...>,
#                    #<Halite::Response HTTP/1.1 200 OK    {"Content-Type" => "application/json" ...>
#                   ] 
```

Thanks @j8r to feedback.