### PR TITLE
Fix instance Halite::Client with empty block

### DIFF
--- a/spec/halite/client_spec.cr
+++ b/spec/halite/client_spec.cr
@@ -19,7 +19,7 @@ describe Halite::Client do
 
     it "should initial with block" do
       client = Halite::Client.new do
-        headers({private_token: "token"})
+        headers(private_token: "token")
         timeout(read: 2.minutes, connect: 40)
       end
 
@@ -28,6 +28,11 @@ describe Halite::Client do
       client.options.headers["Private-Token"].should eq("token")
       client.options.timeout.connect.should eq(40)
       client.options.timeout.read.should eq(120)
+    end
+
+    it "should initial with empty block" do
+      client = Halite::Client.new {}
+      client.should be_a(Halite::Client)
     end
   end
 

--- a/src/halite/client.cr
+++ b/src/halite/client.cr
@@ -71,7 +71,9 @@ module Halite
     def self.new(&block)
       options = Options.new
       instance = Client.new(options)
-      with instance yield
+      value = with instance yield
+      instance = value if value
+      instance
     end
 
     # Instance a new client


### PR DESCRIPTION
```crystal
client = Halite::Client.new {}
client.get "url"
```

throws an exception:
```
undefined method 'put' for Nil
```