### PR TITLE
Streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Build in Crystal version >= `v0.25.0`, this document valid with latest commit.
 - [Advanced Usage](#advanced-usage)
   - [Configuring](#configuring)
   - [Sessions](#sessions)
+  - [Streaming Requests](#streaming-requests)
   - [Logging](#logging)
     - [JSON-formatted logging](#json-formatted-logging)
     - [Write to a log file](#write-to-a-log-file)
@@ -552,6 +553,25 @@ client.options.with_cookie("username": "foobar")
 r = client.get("http://httpbin.org/cookies")
 r.body # => {"cookies":{"username":"foobar"}}
 ```
+
+### Streaming Requests
+
+Similar to [HTTP::Client](https://crystal-lang.org/api/0.27.0/HTTP/Client.html) (search keyword "Streaming") usage with a block,
+you can easily use same way, but Halite returns a `Halite::Response` object:
+
+```crystal
+r = Halite.get("http://httpbin.org/stream/5") do |response|
+  response.status_code                  # => 200
+  response.body_io.each_line do |line|
+    puts JSON.parse(line)               # => {"url" => "http://httpbin.org/stream/5", "args" => {}, "headers" => {"Host" => "httpbin.org", "Connection" => "close", "User-Agent" => "Halite/0.8.0", "Accept" => "*/*", "Accept-Encoding" => "gzip, deflate"}, "id" => 0_i64}
+  end
+end
+```
+
+> **Warning**:
+>
+> `body_io` is avaiabled as an `IO` and not reentrant safe. Might throws a "Nil assertion failed" exception if there is no data in the `IO`
+(such like `head` requests). Calling this method multiple times causes some of the received data being lost.
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -432,19 +432,16 @@ r.parse("yaml") # or "yml"
 
 #### Binary Data
 
-Store binary data(`application/octet-stream`) to file, you can do this:
+Store binary data (eg, `application/octet-stream`) to file, you can use [streaming requests](#streaming-requests):
 
 ```crystal
-r = Halite.get("http://example.com/foo/bar.zip")
-filename = r.headers["Content-Disposition"].split("filename=")[1]
-File.open(filename, "w") do |f|
-  while byte = r.body.read_byte
-    f.write_byte byte
+Halite.get("https://github.com/icyleaf/halite/archive/master.zip") do |response|
+  filename = response.filename || "halite-master.zip"
+  File.open(filename, "w") do |file|
+    IO.copy(response.body_io, file)
   end
 end
 ```
-
-> Use byte to byte will cost more memory and slow down the speed, here has no solution for now, the reason is Crystal only accept streaming by using block with [HTTP::Client](https://crystal-lang.org/api/0.27.0/HTTP/Client.html) (search keyword: **Streaming**).
 
 ### Error Handling
 
@@ -572,6 +569,8 @@ end
 >
 > `body_io` is avaiabled as an `IO` and not reentrant safe. Might throws a "Nil assertion failed" exception if there is no data in the `IO`
 (such like `head` requests). Calling this method multiple times causes some of the received data being lost.
+>
+> One more thing, use streaming requests the response will always [enable redirect](#redirects-and-history) automatically.
 
 ### Logging
 

--- a/spec/halite/client_spec.cr
+++ b/spec/halite/client_spec.cr
@@ -31,7 +31,7 @@ describe Halite::Client do
     end
 
     it "should initial with empty block" do
-      client = Halite::Client.new {}
+      client = Halite::Client.new { }
       client.should be_a(Halite::Client)
     end
   end
@@ -39,20 +39,47 @@ describe Halite::Client do
   describe "#request" do
     %w[get post put delete head patch options].each do |verb|
       it "should easy to #{verb} request" do
-        response = Halite.request(verb, SERVER.endpoint)
+        response = Halite::Client.new.request(verb, SERVER.endpoint)
         response.status_code.should eq(200)
       end
       it "should easy to #{verb} request with hash or namedtuple" do
-        response = Halite.request(verb, SERVER.endpoint, params: {name: "foo"})
+        response = Halite::Client.new.request(verb, SERVER.endpoint, params: {name: "foo"})
         response.status_code.should eq(200)
       end
 
       it "should easy to #{verb} request with options" do
-        response = Halite.request(verb, SERVER.endpoint, Halite::Options.new)
+        response = Halite::Client.new.request(verb, SERVER.endpoint)
         response.status_code.should eq(200)
+      end
+
+      it "should easy to #{verb} streaming request" do
+        data = [] of JSON::Any
+        Halite::Client.new.request(verb, SERVER.api("stream?n=2")) do |response|
+          response.status_code.should eq 200
+          response.headers["Transfer-Encoding"].should eq "chunked"
+
+          if verb != "head"
+            while content = response.body_io.gets
+              data << JSON.parse(content)
+            end
+          else
+            expect_raises Exception, "Nil assertion failed" do
+              response.body_io
+            end
+          end
+        end
+
+        if verb != "head"
+          data.size.should eq 2
+          data.first.as_h["verb"].should eq verb.upcase
+        else
+          data.size.should eq 0
+        end
       end
     end
   end
+
+  # It accepts all chainable methods, see halite_spec.cr
 
   describe "#sessions" do
     it "should store and send cookies" do

--- a/spec/halite/options_spec.cr
+++ b/spec/halite/options_spec.cr
@@ -39,7 +39,7 @@ private def test_options
     follow_strict: false,
     tls: OpenSSL::SSL::Context::Client.new,
     features: {
-      "logging" => Halite::Logging.new.as(Halite::Feature)
+      "logging" => Halite::Logging.new.as(Halite::Feature),
     }
   )
 end
@@ -126,7 +126,7 @@ describe Halite::Options do
         follow: 1,
         tls: new_tls,
         features: {
-          "cache" => Halite::Cache.new.as(Halite::Feature)
+          "cache" => Halite::Cache.new.as(Halite::Feature),
         }
       ))
 
@@ -199,7 +199,7 @@ describe Halite::Options do
         follow: 1,
         tls: new_tls,
         features: {
-          "cache" => Halite::Cache.new.as(Halite::Feature)
+          "cache" => Halite::Cache.new.as(Halite::Feature),
         }
       ))
 
@@ -298,7 +298,7 @@ describe Halite::Options do
     options.tls.should_not be_nil
 
     data = {
-      "name" => "foo".as(Halite::Options::Type)
+      "name" => "foo".as(Halite::Options::Type),
     }
 
     new_options.params = data

--- a/spec/halite_spec.cr
+++ b/spec/halite_spec.cr
@@ -55,12 +55,24 @@ describe Halite do
       end
     end
 
-    # context "loading binary data" do
-    #   it "is encoded as bytes" do
-    #     response = Halite.get SERVER.api("bytes")
-    #     # response.to_s.encoding.should eq(Encoding::BINARY)
-    #   end
-    # end
+    context "loading binary data" do
+      it "is a png file" do
+        response = Halite.get SERVER.api("image")
+        response.headers["Content-Type"].should eq "image/png"
+        response.filename.should eq "logo.png"
+      end
+
+      it "with streaming" do
+        original_path = File.expand_path("../../halite-logo.png", __FILE__)
+        Halite.get SERVER.api("image") do |response|
+          File.open(original_path, "r") do |original_file|
+            while byte = response.body_io.read_byte
+              original_file.read_byte.should eq byte
+            end
+          end
+        end
+      end
+    end
 
     context "with a large request body" do
       [16_000, 16_500, 17_000, 34_000, 68_000].each do |size|

--- a/spec/support/mock_server/route_handler.cr
+++ b/spec/support/mock_server/route_handler.cr
@@ -64,6 +64,24 @@ class MockServer < HTTP::Server
       context
     end
 
+    any "/stream" do |context|
+      total = context.request.query_params["n"].to_i
+
+      body = {
+        "verb"    => context.request.method,
+        "url"     => context.request.resource,
+        "query"   => context.request.query,
+        "headers" => context.request.headers.to_flat_h,
+      }
+
+      total.times do |i|
+        context.response.puts body.to_json
+        context.response.flush
+      end
+
+      context
+    end
+
     # GET
     get "/" do |context|
       context.response.status_code = 200

--- a/spec/support/mock_server/route_handler.cr
+++ b/spec/support/mock_server/route_handler.cr
@@ -130,6 +130,17 @@ class MockServer < HTTP::Server
       context
     end
 
+    get "/image" do |context|
+      path = File.expand_path("../../../../halite-logo.png", __FILE__)
+      context.response.content_type = "image/png"
+      context.response.content_length = File.size(path)
+      context.response.headers["Content-Disposition"] = "attachment; filename=logo.png"
+      File.open(path) do |file|
+        IO.copy(file, context.response)
+      end
+      context
+    end
+
     get "/redirect-301" do |context|
       context.response.status_code = 301
       location =

--- a/src/halite/client.cr
+++ b/src/halite/client.cr
@@ -95,15 +95,15 @@ module Halite
     #
     # client = Halite::Client.new(options)
     # ```
-    def initialize(@options = Options.new)
+    def initialize(@options = Halite::Options.new)
       @history = [] of Response
     end
 
     # Make an HTTP request
-    def request(verb : String, uri : String, options : Options? = nil) : Halite::Response
+    def request(verb : String, uri : String, options : Halite::Options? = nil) : Halite::Response
       opts = options ? @options.merge(options.not_nil!) : @options
       request = build_request(verb, uri, opts)
-      response = perform(request, opts) do
+      response = perform_chain(request, opts) do
         perform(request, opts)
       end
 
@@ -114,8 +114,15 @@ module Halite
       end
     end
 
+    # Make an HTTP request
+    def request(verb : String, uri : String, options : Halite::Options? = nil, &block : Halite::Response ->)
+      opts = options ? @options.merge(options.not_nil!) : @options
+      request = build_request(verb, uri, opts)
+      perform(request, opts, &block)
+    end
+
     # Find interceptor and return `Response` else perform HTTP request.
-    private def perform(request : Halite::Request, options : Halite::Options, &block : -> Response)
+    private def perform_chain(request : Halite::Request, options : Halite::Options, &block : -> Response)
       chain = Feature::Chain.new(request, nil, options, &block)
       options.features.each do |_, feature|
         current_chain = feature.intercept(chain)
@@ -139,20 +146,28 @@ module Halite
     private def perform(request : Halite::Request, options : Halite::Options) : Halite::Response
       raise RequestError.new("SSL context given for HTTP URI = #{request.uri}") if request.scheme == "http" && options.tls
 
-      conn = HTTP::Client.new(request.domain, options.tls)
-      conn.connect_timeout = options.timeout.connect.not_nil! if options.timeout.connect
-      conn.read_timeout = options.timeout.read.not_nil! if options.timeout.read
+      conn = make_connection(request, options)
       conn_response = conn.exec(request.verb, request.full_path, request.headers, request.body)
-      response = Response.new(uri: request.uri, conn: conn_response, history: @history)
-      handle_response(response, options)
+      handle_response(request, conn_response, options)
     rescue ex : IO::Timeout
       raise TimeoutError.new(ex.message)
     rescue ex : Socket::Error | Errno
       raise ConnectionError.new(ex.message)
     end
 
+    # Perform a single (no follow) streaming HTTP request
+    private def perform(request : Halite::Request, option : Halite::Options, &block : Halite::Response ->)
+      raise RequestError.new("SSL context given for HTTP URI = #{request.uri}") if request.scheme == "http" && options.tls
+
+      conn = make_connection(request, options)
+      conn.exec(request.verb, request.full_path, request.headers, request.body) do |conn_response|
+        response = handle_response(request, conn_response, options)
+        yield response
+      end
+    end
+
     # Prepare a HTTP request
-    private def build_request(verb : String, uri : String, options : Options) : Halite::Request
+    private def build_request(verb : String, uri : String, options : Halite::Options) : Halite::Request
       uri = make_request_uri(uri, options)
       body_data = make_request_body(options)
       headers = make_request_headers(options, body_data.content_type)
@@ -206,6 +221,20 @@ module Halite
       end
     end
 
+    # Create the http connection
+    private def make_connection(request, options)
+      conn = HTTP::Client.new(request.domain, options.tls)
+      conn.connect_timeout = options.timeout.connect.not_nil! if options.timeout.connect
+      conn.read_timeout = options.timeout.read.not_nil! if options.timeout.read
+      conn
+    end
+
+    # Convert HTTP::Client::Response to response and handles response (see below)
+    private def handle_response(request, conn_response : HTTP::Client::Response, options)
+      response = Response.new(uri: request.uri, conn: conn_response, history: @history)
+      handle_response(response, options)
+    end
+
     # Handles response by reduce the response of feature, add history and update options
     private def handle_response(response, options)
       response = options.features.reduce(response) do |res, (_, feature)|
@@ -225,7 +254,7 @@ module Halite
     end
 
     # Use in instance/session mode, it will replace same method in `Halite::Chainable`.
-    private def branch(options : Options? = nil)
+    private def branch(options : Halite::Options? = nil)
       oneshot_options.merge!(options)
       self
     end

--- a/src/halite/error.cr
+++ b/src/halite/error.cr
@@ -21,6 +21,9 @@ module Halite
     # The scheme given was not understood
     class UnsupportedSchemeError < RequestError; end
 
+    # The head method can not streaming without empty response
+    class UnsupportedStreamMethodError < RequestError; end
+
     # Requested to do something when we're in the wrong state
     class StateError < RequestError; end
 

--- a/src/halite/feature.cr
+++ b/src/halite/feature.cr
@@ -34,9 +34,9 @@ module Halite
       getter response
       getter result
 
-      @performed_response : Response?
+      @performed_response : Halite::Response?
 
-      def initialize(@request : Request, @response : Response?, @options : Options, &block : -> Response)
+      def initialize(@request : Halite::Request, @response : Halite::Response?, @options : Halite::Options, &block : -> Halite::Response)
         @result = Result::Next
         @performed_response = nil
         @perform_request_block = block

--- a/src/halite/features/logging.cr
+++ b/src/halite/features/logging.cr
@@ -44,7 +44,7 @@ module Halite
         new(skip_request_body, skip_response_body, skip_benchmark, colorize, io)
       end
 
-      setter logger : ::Logger
+      setter logger : Logger
       getter skip_request_body : Bool
       getter skip_response_body : Bool
       getter skip_benchmark : Bool

--- a/src/halite/form_data.cr
+++ b/src/halite/form_data.cr
@@ -19,7 +19,7 @@ module Halite
   # ```
   module FormData
     # FormData factory. Automatically selects best type depending on given `data` Hash
-    def self.create(data : Hash(String, Options::Type) = {} of String => Options::Type) : Halite::Request::Data
+    def self.create(data : Hash(String, Halite::Options::Type) = {} of String => Halite::Options::Type) : Halite::Request::Data
       if multipart?(data)
         io = IO::Memory.new
         builder = HTTP::FormData::Builder.new(io)
@@ -50,7 +50,7 @@ module Halite
     end
 
     # Tells whenever data contains multipart data or not.
-    private def self.multipart?(data : Hash(String, Options::Type)) : Bool
+    private def self.multipart?(data : Hash(String, Halite::Options::Type)) : Bool
       data.any? do |_, v|
         case v
         when File

--- a/src/halite/redirector.cr
+++ b/src/halite/redirector.cr
@@ -18,7 +18,7 @@ module Halite
     getter max_hops : Int32
 
     # Instance a new Redirector
-    def initialize(@request : Request, @response : Response, @max_hops = 5, @strict = true)
+    def initialize(@request : Halite::Request, @response : Halite::Response, @max_hops = 5, @strict = true)
       @visited = [] of String
     end
 

--- a/src/halite/response.cr
+++ b/src/halite/response.cr
@@ -1,7 +1,7 @@
 module Halite
   class Response
     def self.new(uri : URI, status_code : Int32, body : String? = nil, headers = HTTP::Headers.new,
-                 status_message = nil, body_io : IO? = nil, version = "HTTP/1.1", history = [] of Response)
+                 status_message = nil, body_io : IO? = nil, version = "HTTP/1.1", history = [] of Halite::Response)
       conn = HTTP::Client::Response.new(status_code, body, headers, status_message, version, body_io)
       new(uri, conn, history)
     end
@@ -10,7 +10,7 @@ module Halite
     getter conn
     getter history : Array(Response)
 
-    def initialize(@uri : URI, @conn : HTTP::Client::Response, @history = [] of Response)
+    def initialize(@uri : URI, @conn : HTTP::Client::Response, @history = [] of Halite::Response)
     end
 
     delegate version, to: @conn
@@ -46,7 +46,7 @@ module Halite
     end
 
     # Return a list of parsed link headers proxies or else nil.
-    def links : Hash(String, HeaderLink)?
+    def links : Hash(String, Halite::HeaderLink)?
       parse_links_from_headers
     end
 

--- a/src/halite/response.cr
+++ b/src/halite/response.cr
@@ -84,6 +84,13 @@ module Halite
       MimeType[name].decode to_s
     end
 
+    # Return filename if it exists, else `Nil`.
+    def filename : String?
+      headers["Content-Disposition"]?.try do |value|
+        value.split("filename=")[1]
+      end
+    end
+
     # Return raw of response
     def to_raw
       io = IO::Memory.new


### PR DESCRIPTION
Similar to [HTTP::Client](https://crystal-lang.org/api/0.27.0/HTTP/Client.html) (search keyword "Streaming") but Halite returns a `Halite::Response` object:

```crystal
Halite.get "http://httpbin.org/stream/3" do |response|
  puts response.status_code
  while line = response.body_io.gets
    puts line
    puts "*" * 10
  end
end
```

Use streaming requests we can store binary data chunk by chunk: 

```crystal
Halite.get("https://github.com/icyleaf/halite/archive/master.zip") do |response|
  filename = response.filename || "halite-master.zip"
  File.open(filename, "w") do |file|
    IO.copy(response.body_io, file)
  end
end
```

Relates #49 