### PR TITLE
Moved default headers to request to make Options clear

### DIFF
--- a/spec/halite/options_spec.cr
+++ b/spec/halite/options_spec.cr
@@ -49,7 +49,7 @@ describe Halite::Options do
     it "should initial with nothing" do
       options = Halite::Options.new
       options.should be_a(Halite::Options)
-      options.headers.should eq(HTTP::Headers{"User-Agent" => "Halite/#{Halite::VERSION}", "Accept" => "*/*", "Connection" => "keep-alive"})
+      options.headers.empty?.should be_true
 
       options.cookies.should be_a(HTTP::Cookies)
       options.cookies.size.should eq(0)
@@ -130,7 +130,7 @@ describe Halite::Options do
         }
       ))
 
-      old_options.headers.should eq(HTTP::Headers{"User-Agent" => "spec", "Accept" => "*/*", "Connection" => "keep-alive"})
+      old_options.headers.should eq(HTTP::Headers{"User-Agent" => "spec"})
       old_options.cookies.size.should eq(0)
       old_options.timeout.connect.should eq(1)
       old_options.timeout.read.should eq(3.2)
@@ -145,7 +145,7 @@ describe Halite::Options do
       old_options.features["logging"].should be_a(Halite::Logging)
       old_options.tls.not_nil!.should_not eq(new_tls)
 
-      options.headers.should eq(HTTP::Headers{"User-Agent" => "new_spec", "Accept" => "*/*", "Connection" => "keep-alive"})
+      options.headers.should eq(HTTP::Headers{"User-Agent" => "new_spec"})
       options.cookies.size.should eq(0)
       options.timeout.connect.should eq(2)
       options.timeout.read.should be_nil
@@ -162,12 +162,6 @@ describe Halite::Options do
       options.features.size.should eq(2)
       options.features["logging"].should be_a(Halite::Logging)
       options.features["cache"].should be_a(Halite::Cache)
-    end
-
-    it "should keep defaults headers if same as others" do
-      options = Halite::Options.new
-      new_options = options.merge(Halite::Options.new)
-      new_options.headers.should eq(options.default_headers)
     end
 
     it "should overwrite exists value of headers from other" do
@@ -203,7 +197,7 @@ describe Halite::Options do
         }
       ))
 
-      old_options.headers.should eq(HTTP::Headers{"User-Agent" => "new_spec", "Accept" => "*/*", "Connection" => "keep-alive"})
+      old_options.headers.should eq(HTTP::Headers{"User-Agent" => "new_spec"})
       old_options.cookies.size.should eq(0)
       old_options.timeout.connect.should eq(2)
       old_options.timeout.read.should be_nil
@@ -220,7 +214,7 @@ describe Halite::Options do
       options.features["logging"].should be_a(Halite::Logging)
       options.features["cache"].should be_a(Halite::Cache)
 
-      options.headers.should eq(HTTP::Headers{"User-Agent" => "new_spec", "Accept" => "*/*", "Connection" => "keep-alive"})
+      options.headers.should eq(HTTP::Headers{"User-Agent" => "new_spec"})
       options.cookies.size.should eq(0)
       options.timeout.connect.should eq(2)
       options.timeout.read.should be_nil
@@ -242,7 +236,7 @@ describe Halite::Options do
   describe "#clear!" do
     options = test_options
     options.clear!
-    options.headers.should eq(HTTP::Headers{"User-Agent" => "Halite/#{Halite::VERSION}", "Accept" => "*/*", "Connection" => "keep-alive"})
+    options.headers.size.should eq(0)
 
     options.cookies.should be_a(HTTP::Cookies)
     options.cookies.size.should eq(0)
@@ -273,7 +267,7 @@ describe Halite::Options do
 
     new_options.headers = HTTP::Headers.new
     new_options.headers.empty?.should be_true
-    options.headers.size.should eq(3)
+    options.headers.size.should eq(1)
 
     cookies = HTTP::Cookies.new
     cookies << HTTP::Cookie.new("name", "foobar")
@@ -406,7 +400,7 @@ describe Halite::Options do
       options = options.with_follow(follow: 5, strict: false)
 
       options.follow.hops.should eq(5)
-      options.follow.strict.should eq(false)
+      options.follow.strict.should be_false
     end
   end
 
@@ -490,14 +484,14 @@ describe Halite::Options do
       )
       options.clear!
 
-      options.headers.should eq(options.default_headers)
-      options.cookies.empty?.should eq(true)
-      options.params.empty?.should eq(true)
-      options.form.empty?.should eq(true)
-      options.json.empty?.should eq(true)
+      options.headers.empty?.should be_true
+      options.cookies.empty?.should be_true
+      options.params.empty?.should be_true
+      options.form.empty?.should be_true
+      options.json.empty?.should be_true
 
-      options.timeout.connect.nil?.should eq(true)
-      options.timeout.read.nil?.should eq(true)
+      options.timeout.connect.nil?.should be_true
+      options.timeout.read.nil?.should be_true
 
       options.follow.hops.should eq(Halite::Follow::DEFAULT_HOPS)
       options.follow.strict.should eq(Halite::Follow::STRICT)
@@ -566,17 +560,17 @@ describe Halite::Options do
         options = Halite::Options.new
 
         options.follow_strict = false
-        options.follow.strict.should eq(false)
+        options.follow.strict.should be_false
 
         options.follow.strict = true
-        options.follow.strict.should eq(true)
+        options.follow.strict.should be_true
       end
 
       it "getter" do
         options = Halite::Options.new(follow: Halite::Follow.new(strict: false))
 
-        options.follow_strict.should eq(false)
-        options.follow.strict.should eq(false)
+        options.follow_strict.should be_false
+        options.follow.strict.should be_false
       end
     end
   end

--- a/spec/halite/request_spec.cr
+++ b/spec/halite/request_spec.cr
@@ -27,8 +27,8 @@ describe Halite::Request do
     end
 
     it "could not set header with key and value" do
-      request.headers["User-Agent"] = "Halite"
-      request.headers["User-Agent"]?.should eq nil
+      request.headers["Via"] = "Halite"
+      request.headers["Via"]?.should eq nil
     end
   end
 

--- a/src/halite/options.cr
+++ b/src/halite/options.cr
@@ -36,9 +36,6 @@ module Halite
   # o.follow.strict # => false
   # ```
   class Options
-    # Request user-agent by default
-    USER_AGENT = "Halite/#{Halite::VERSION}"
-
     def self.new(headers : (Hash(String, _) | NamedTuple)? = nil,
                  cookies : (Hash(String, _) | NamedTuple)? = nil,
                  params : (Hash(String, _) | NamedTuple)? = nil,
@@ -92,7 +89,7 @@ module Halite
                    @follow = Follow.new,
                    @tls : OpenSSL::SSL::Context::Client? = nil,
                    @features = {} of String => Feature)
-      @headers = default_headers.merge!(parse_headers(headers))
+      @headers = parse_headers(headers)
       @cookies = parse_cookies(cookies)
       @params = parse_params(params)
       @form = parse_form(form)
@@ -280,15 +277,7 @@ module Halite
 
     # Merge with other `Options` and return self
     def merge!(other : Halite::Options) : Halite::Options
-      # if other.headers != default_headers
-      #   # Remove default key to make sure it is not to overwrite new one.
-      #   default_headers.each do |key, value|
-      #     other.headers.delete(key) if other.headers.get?(key) == value
-      #   end
-
-      #   @headers.merge!(other.headers)
-      # end
-      @headers.merge!(other.headers) if other.headers != default_headers
+      @headers.merge!(other.headers)
 
       other.cookies.each do |cookie|
         @cookies << cookie
@@ -314,7 +303,7 @@ module Halite
 
     # Reset options
     def clear! : Halite::Options
-      @headers = default_headers
+      @headers = HTTP::Headers.new
       @cookies = HTTP::Cookies.new
       @params = {} of String => Type
       @form = {} of String => Type
@@ -344,17 +333,6 @@ module Halite
         tls: @tls
       )
       options
-    end
-
-    # Return default headers
-    #
-    # Auto accept gzip deflate encoding by [HTTP::Client](https://crystal-lang.org/api/0.25.1/HTTP/Client.html)
-    def default_headers : HTTP::Headers
-      HTTP::Headers{
-        "User-Agent" => USER_AGENT,
-        "Accept"     => "*/*",
-        "Connection" => "keep-alive",
-      }
     end
 
     # Returns this collection as a plain Hash.

--- a/src/halite/request.cr
+++ b/src/halite/request.cr
@@ -8,6 +8,9 @@ module Halite
     # Allowed schemes
     SCHEMES = %w(http https)
 
+    # Request user-agent by default
+    USER_AGENT = "Halite/#{Halite::VERSION}"
+
     # The verb name of request
     getter verb : String
 
@@ -33,6 +36,9 @@ module Halite
       @scheme = @uri.scheme.not_nil!
 
       raise UnsupportedSchemeError.new("Unknown scheme: #{@scheme}") unless SCHEMES.includes?(@scheme)
+
+      @headers["User-Agent"] ||= USER_AGENT
+      @headers["Connection"] ||= "close"
     end
 
     # Returns new Request with updated uri


### PR DESCRIPTION
This PR is remove `default_headers`(user_agent/connect/accept) make `Halite::Options` clear, and move to `Halite::Request`.

And this also can fix merge issues with the other default headers.