### PR TITLE
user_agent method

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Build in Crystal version >= `v0.25.0`, this document valid with latest commit.
     - [JSON data](#json-data)
     - [Raw String](#raw-string)
   - [Passing advanced options](#passing-advanced-options)
-    - [Headers](#headers)
     - [Auth](#auth)
+    - [User Agent](#user-agent)
+    - [Headers](#headers)
     - [Cookies](#cookies)
     - [Redirects and History](#redirects-and-history)
     - [Timeout](#timeout)
@@ -202,6 +203,25 @@ Halite.post("http://httpbin.org/post",
 
 ### Passing advanced options
 
+#### Auth
+
+Use the `#basic_auth` method to perform [HTTP Basic Authentication](http://tools.ietf.org/html/rfc2617) using a username and password:
+
+```crystal
+Halite.basic_auth(user: "user", password: "p@ss").get("http://httpbin.org/get")
+
+# We can pass a raw authorization header using the auth method:
+Halite.auth("Bearer dXNlcjpwQHNz").get("http://httpbin.org/get")
+```
+
+#### User Agent
+
+Use the `#user_agent` method to overwrite default one:
+
+```crystal
+Halite.user_agent("Crystal Client").get("http://httpbin.org/user-agent")
+```
+
 #### Headers
 
 Here are two way to passing headers data:
@@ -224,17 +244,6 @@ Halite.headers({ private_token: "T0k3n" }).get("http://httpbin.org/get")
 Halite.get("http://httpbin.org/anything" , headers: { private_token: "T0k3n" })
 
 Halite.post("http://httpbin.org/anything" , headers: { private_token: "T0k3n" })
-```
-
-#### Auth
-
-Use the `#basic_auth` method to perform [HTTP Basic Authentication](http://tools.ietf.org/html/rfc2617) using a username and password:
-
-```crystal
-Halite.basic_auth(user: "user", password: "p@ss").get("http://httpbin.org/get")
-
-# We can pass a raw authorization header using the auth method:
-Halite.auth("Bearer dXNlcjpwQHNz").get("http://httpbin.org/get")
 ```
 
 #### Cookies

--- a/spec/halite_spec.cr
+++ b/spec/halite_spec.cr
@@ -418,6 +418,22 @@ describe Halite do
     end
   end
 
+  describe ".user_agent" do
+    it "uses default user agent" do
+      r = Halite.get SERVER.api("user_agent")
+      r.body.should eq(Halite::Request::USER_AGENT)
+    end
+
+    it "sets user agent" do
+      user_agent = "Awesome Halite Client"
+      client = Halite.user_agent(user_agent)
+      client.options.headers["User-Agent"].should eq(user_agent)
+
+      r = client.get SERVER.api("user_agent")
+      r.body.should eq(user_agent)
+    end
+  end
+
   describe ".timeout" do
     context "without timeout type" do
       it "sets given timeout options" do

--- a/spec/support/mock_server/route_handler.cr
+++ b/spec/support/mock_server/route_handler.cr
@@ -218,6 +218,12 @@ class MockServer < HTTP::Server
       context
     end
 
+    get "/user_agent" do |context|
+      body = context.request.headers["User-Agent"]
+      context.response.print body
+      context
+    end
+
     # POST
     post "/" do |context|
       context.response.status_code = 200

--- a/src/halite/chainable.cr
+++ b/src/halite/chainable.cr
@@ -129,6 +129,16 @@ module Halite
       headers({"Accept" => value})
     end
 
+    # Set requests user agent
+    #
+    # ```
+    # Halite.user_agent("Custom User Agent")
+    #   .get("http://httpbin.org/get")
+    # ```
+    def user_agent(value : String) : Halite::Client
+      headers({"User-Agent" => value})
+    end
+
     # Make a request with the given headers
     #
     # ```


### PR DESCRIPTION
Add new `#user_agent` method will let developer can easy overwrite the default one in Halite. by default, use `Halite::Request::USER_AGENT`

```crystal
Halite.user_agent("Crystal Client").get("http://httpbin.org/user-agent")
```