### PR TITLE
Feature: client endpoint

### DIFF
--- a/spec/halite/client_spec.cr
+++ b/spec/halite/client_spec.cr
@@ -2,6 +2,8 @@ require "../spec_helper"
 require "../support/mock_server"
 
 describe Halite::Client do
+  # It accepts all chainable methods, see spec/halite_spec.cr
+
   describe "#initialize" do
     it "should initial with nothing" do
       client = Halite::Client.new
@@ -36,12 +38,43 @@ describe Halite::Client do
     end
   end
 
+  describe "#endpoint" do
+    it "should set String from arguments" do
+      client = Halite::Client.new(endpoint: SERVER.endpoint)
+      response = client.get("/")
+      response.status_code.should eq(200)
+    end
+
+    it "should set String from block" do
+      client = Halite::Client.new do
+        endpoint SERVER.endpoint
+      end
+
+      response = client.get("")
+      response.status_code.should eq(200)
+    end
+
+    it "should always overwrite the path of uri if path starts with '/' char" do
+      client = Halite::Client.new do
+        endpoint "#{SERVER.endpoint}/redirect-301"
+      end
+
+      response = client.get("")
+      response.status_code.should eq(301)
+
+      response = client.accept("application/json").get("/")
+      response.status_code.should eq(200)
+      response.to_s.should match(/json/)
+    end
+  end
+
   describe "#request" do
     %w[get post put delete head patch options].each do |verb|
       it "should easy to #{verb} request" do
         response = Halite::Client.new.request(verb, SERVER.endpoint)
         response.status_code.should eq(200)
       end
+
       it "should easy to #{verb} request with hash or namedtuple" do
         response = Halite::Client.new.request(verb, SERVER.endpoint, params: {name: "foo"})
         response.status_code.should eq(200)
@@ -78,8 +111,6 @@ describe Halite::Client do
       end
     end
   end
-
-  # It accepts all chainable methods, see halite_spec.cr
 
   describe "#sessions" do
     it "should store and send cookies" do

--- a/spec/halite_spec.cr
+++ b/spec/halite_spec.cr
@@ -404,6 +404,20 @@ describe Halite do
     end
   end
 
+  describe ".endpoint" do
+    it "sets endpoint with String" do
+      endpoint = "https://example.com"
+      client = Halite.endpoint(endpoint)
+      client.options.endpoint.should eq(URI.parse(endpoint))
+    end
+
+    it "sets endpoint with String" do
+      endpoint = URI.parse("https://example.com")
+      client = Halite.endpoint(endpoint)
+      client.options.endpoint.should eq(endpoint)
+    end
+  end
+
   describe ".auth" do
     it "sets Authorization header to the given value" do
       client = Halite.auth("abc")

--- a/src/halite.cr
+++ b/src/halite.cr
@@ -4,6 +4,8 @@ require "./halite/ext/*"
 module Halite
   extend Chainable
 
+  VERSION = "0.9.2"
+
   @@features = {} of String => Feature.class
 
   module FeatureRegister

--- a/src/halite/chainable.cr
+++ b/src/halite/chainable.cr
@@ -97,6 +97,17 @@ module Halite
       end
     {% end %}
 
+    # Adds a endpoint to the request.
+    #
+    #
+    # ```
+    # Halite.endpoint("https://httpbin.org")
+    #   .get("/get")
+    # ```
+    def endpoint(endpoint : String | URI) : Halite::Client
+      branch(default_options.with_endpoint(endpoint))
+    end
+
     # Make a request with the given Basic authorization header
     #
     # ```

--- a/src/halite/client.cr
+++ b/src/halite/client.cr
@@ -42,6 +42,7 @@ module Halite
     # Halite::Client.new(headers: {"private-token" => "bdf39d82661358f80b31b67e6f89fee4"})
     # ```
     def self.new(*,
+                 endpoint : (String | URI)? = nil,
                  headers : (Hash(String, _) | NamedTuple)? = nil,
                  cookies : (Hash(String, _) | NamedTuple)? = nil,
                  params : (Hash(String, _) | NamedTuple)? = nil,
@@ -52,6 +53,7 @@ module Halite
                  follow = Follow.new,
                  tls : OpenSSL::SSL::Context::Client? = nil)
       new(Options.new(
+        endpoint: endpoint,
         headers: headers,
         cookies: cookies,
         params: params,
@@ -191,8 +193,14 @@ module Halite
     end
 
     # Merges query params if needed
-    private def make_request_uri(uri : String, options : Halite::Options) : String
-      uri = URI.parse uri
+    private def make_request_uri(url : String, options : Halite::Options) : String
+      if endpoint = options.endpoint
+        uri = endpoint
+        uri.path = url.starts_with?("/") ? url : "#{uri.path}/#{url}" unless url.empty?
+      else
+        uri = URI.parse(url)
+      end
+
       if params = options.params
         query = HTTP::Params.encode(params)
         uri.query = [uri.query, query].compact.join("&") unless query.empty?

--- a/src/halite/client.cr
+++ b/src/halite/client.cr
@@ -196,7 +196,7 @@ module Halite
     private def make_request_uri(url : String, options : Halite::Options) : String
       if endpoint = options.endpoint
         uri = endpoint
-        uri.path = url.starts_with?("/") ? url : "#{uri.path}/#{url}" unless url.empty?
+        uri.path = url[0] == '/' ? url : "#{uri.path}/#{url}" unless url.empty? || uri.path == url
       else
         uri = URI.parse(url)
       end
@@ -206,7 +206,6 @@ module Halite
         uri.query = [uri.query, query].compact.join("&") unless query.empty?
       end
 
-      uri.path = "/" if uri.path.to_s.empty?
       uri.to_s
     end
 

--- a/src/halite/version.cr
+++ b/src/halite/version.cr
@@ -1,3 +1,0 @@
-module Halite
-  VERSION = "0.9.2"
-end


### PR DESCRIPTION
Usages:

### Quick shot

```crystal
Halite.endpoint("https://httpbin.org").get("/get")
```

### Use endpoint as configuration 

```crystal
client  = Halite::Client.new(endpoint: "https://httpbin.org")
# Or
client  = Halite::Client.new do
  endpoint "https://httpbin.org"
end

client.get("/get")
```

### Overwrite the path of endpoint

```crystal
client  = Halite::Client.new do
  endpoint "https://example.com/api"
end

client.get("users")      # GET https://example.com/api/users
client.get("/users")     # GET https://example.com/users
```

/relates #64 