### PR TITLE
Use File.join instead of concetination for url

### DIFF
--- a/src/halite/client.cr
+++ b/src/halite/client.cr
@@ -196,7 +196,7 @@ module Halite
     private def make_request_uri(url : String, options : Halite::Options) : String
       if endpoint = options.endpoint
         uri = endpoint
-        uri.path = url[0] == '/' ? url : "#{uri.path}/#{url}" unless url.empty? || uri.path == url
+        uri.path = url[0] == '/' ? url : File.join(uri.path, url) unless url.empty? || uri.path == url
       else
         uri = URI.parse(url)
       end


### PR DESCRIPTION
Should fix and close #64. Uses `File.join` to join url parts instead of relying on string concatenation.