### PR TITLE
Support write timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  test_crystal_0_31:
+  test_crystal_0_32:
     docker:
-      - image: "crystallang/crystal:0.31.0"
+      - image: "crystallang/crystal:0.32.0"
     environment:
       DOCS_PATH: "docs"
       GIT_USER: "icyleaf"
@@ -32,7 +32,7 @@ workflows:
   version: 2
   build_test_deploy:
     jobs:
-      - test_crystal_0_31:
+      - test_crystal_0_32:
           filters:
             branches:
               ignore:

--- a/.circleci/generate_docs.sh
+++ b/.circleci/generate_docs.sh
@@ -2,7 +2,7 @@
 
 DOCS_PATH="docs"
 TAGS=$(git tag -l)
-DEFAULT_VERSION=$(git tag --merged master | sort | tail -n 1)
+DEFAULT_VERSION=$(git tag --merged master | sort -V | tail -n 1)
 DEFAULT_VERSION=$(echo $DEFAULT_VERSION | awk '{gsub(/^v/, ""); print}')
 
 # Clean up

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.10.4
 authors:
   - icyleaf <icyleaf.cn@gmail.com>
 
-crystal: 0.31.0
+crystal: 0.32.0
 
 license: MIT

--- a/spec/halite/client_spec.cr
+++ b/spec/halite/client_spec.cr
@@ -108,7 +108,7 @@ describe Halite::Client do
               data << JSON.parse(content)
             end
           else
-            expect_raises Exception, "Nil assertion failed" do
+            expect_raises NilAssertionError do
               response.body_io
             end
           end

--- a/spec/halite/options/timeout_spec.cr
+++ b/spec/halite/options/timeout_spec.cr
@@ -3,45 +3,57 @@ require "../../spec_helper"
 describe Halite::Timeout do
   describe "#initialize" do
     it "should set with Int32" do
-      timeout = Halite::Timeout.new(1, 2)
+      timeout = Halite::Timeout.new(1, 2, 3)
       timeout.connect.should eq(1.0)
       timeout.read.should eq(2)
+      timeout.write.should eq(3)
     end
 
     it "should set with Float64" do
-      timeout = Halite::Timeout.new(1.2, 3.4)
+      timeout = Halite::Timeout.new(1.2, 3.4, 5.6)
       timeout.connect.should eq(1.2)
       timeout.read.should eq(3.4)
+      timeout.write.should eq(5.6)
     end
 
     it "should set with Time::Span" do
-      timeout = Halite::Timeout.new(1.seconds, 1.minutes)
+      timeout = Halite::Timeout.new(1.seconds, 1.minutes, 1.hour)
       timeout.connect.should eq(1.0)
       timeout.read.should eq(60.0)
+      timeout.write.should eq(3600.0)
     end
 
     it "should set different format" do
-      timeout = Halite::Timeout.new(1, 1.minutes)
+      timeout = Halite::Timeout.new(1, 1.minutes, 10.0)
       timeout.connect.should eq(1.0)
       timeout.read.should eq(60.0)
+      timeout.write.should eq(10.0)
 
-      timeout = Halite::Timeout.new(1.2, 1)
+      timeout = Halite::Timeout.new(1.2, 1, Time::Span.new(seconds: 30, nanoseconds: 0))
       timeout.connect.should eq(1.2)
       timeout.read.should eq(1.0)
+      timeout.write.should eq(30.0)
     end
 
     it "should set one argument" do
       timeout = Halite::Timeout.new(1)
       timeout.connect.should eq(1.0)
       timeout.read.should be_nil
+      timeout.write.should be_nil
 
       timeout = Halite::Timeout.new(connect: 2)
       timeout.connect.should eq(2.0)
       timeout.read.should be_nil
+      timeout.write.should be_nil
 
       timeout = Halite::Timeout.new(read: 3)
       timeout.connect.should be_nil
       timeout.read.should eq(3.0)
+
+      timeout = Halite::Timeout.new(write: 3)
+      timeout.connect.should be_nil
+      timeout.read.should be_nil
+      timeout.write.should eq(3.0)
     end
   end
 
@@ -53,6 +65,9 @@ describe Halite::Timeout do
 
       timeout.read = 12
       timeout.read.should eq(12.0)
+
+      timeout.write = 1
+      timeout.write.should eq(1.0)
     end
 
     it "should set with Float64" do
@@ -62,6 +77,9 @@ describe Halite::Timeout do
 
       timeout.read = 12.0
       timeout.read.should eq(12.0)
+
+      timeout.write = 1.0
+      timeout.write.should eq(1.0)
     end
 
     it "should set with Time::Span" do
@@ -71,6 +89,9 @@ describe Halite::Timeout do
 
       timeout.read = 1.minutes
       timeout.read.should eq(60.0)
+
+      timeout.write = 1.hour
+      timeout.write.should eq(3600.0)
     end
   end
 end

--- a/spec/halite_spec.cr
+++ b/spec/halite_spec.cr
@@ -105,6 +105,18 @@ describe Halite do
             end
           end
         end
+
+        [nil, 10, {connect: 2, read: 2, write: 2}].each do |timeout|
+          context "with `.timeout(#{timeout.inspect})`" do
+            it "writes the whole body" do
+              body =  "“" * 1_000_000
+              response = Halite.post SERVER.api("echo-body"), raw: body
+
+              response.to_s.should eq(body)
+              response.content_length.should eq(body.bytesize)
+            end
+          end
+        end
       end
     end
   end
@@ -467,9 +479,10 @@ describe Halite do
   describe ".timeout" do
     context "without timeout type" do
       it "sets given timeout options" do
-        client = Halite.timeout(connect: 12, read: 6)
-        client.options.timeout.read.should eq(6)
+        client = Halite.timeout(connect: 12, read: 6, write: 36)
         client.options.timeout.connect.should eq(12)
+        client.options.timeout.read.should eq(6)
+        client.options.timeout.write.should eq(36)
       end
     end
   end

--- a/spec/halite_spec.cr
+++ b/spec/halite_spec.cr
@@ -338,7 +338,7 @@ describe Halite do
               data << JSON.parse(content)
             end
           else
-            expect_raises Exception, "Nil assertion failed" do
+            expect_raises NilAssertionError do
               response.body_io
             end
           end

--- a/src/halite/chainable.cr
+++ b/src/halite/chainable.cr
@@ -212,14 +212,16 @@ module Halite
     # How long to wait for the server to send data before giving up, as a int, float or time span.
     # The timeout value will be applied to both the connect and the read timeouts.
     #
+    # Set `nil` to timeout to ignore timeout.
+    #
     # ```
     # Halite.timeout(5.5).get("http://httpbin.org/get")
     # # Or
     # Halite.timeout(2.minutes)
     #   .post("http://httpbin.org/post", form: {file: "file.txt"})
     # ```
-    def timeout(connect_and_read : Int32 | Float64 | Time::Span) : Halite::Client
-      timeout(connect_and_read, connect_and_read)
+    def timeout(timeout : Int32? | Float64? | Time::Span?)
+      timeout ? timeout(timeout, timeout, timeout) : branch
     end
 
     # Adds a timeout to the request.
@@ -228,14 +230,16 @@ module Halite
     # The timeout value will be applied to both the connect and the read timeouts.
     #
     # ```
-    # Halite.timeout(3, 3.minutes)
+    # Halite.timeout(3, 3.minutes, 5)
     #   .post("http://httpbin.org/post", form: {file: "file.txt"})
     # # Or
-    # Halite.timeout(3.04, 64)
+    # Halite.timeout(3.04, 64, 10.0)
     #   .get("http://httpbin.org/get")
     # ```
-    def timeout(connect : (Int32 | Float64 | Time::Span)? = nil, read : (Int32 | Float64 | Time::Span)? = nil) : Halite::Client
-      branch(default_options.with_timeout(connect, read))
+    def timeout(connect : (Int32 | Float64 | Time::Span)? = nil,
+                read : (Int32 | Float64 | Time::Span)? = nil,
+                write : (Int32 | Float64 | Time::Span)? = nil)
+      branch(default_options.with_timeout(connect, read, write))
     end
 
     # Returns `Options` self with automatically following redirects.

--- a/src/halite/client.cr
+++ b/src/halite/client.cr
@@ -248,6 +248,7 @@ module Halite
       conn = HTTP::Client.new(request.domain, options.tls)
       conn.connect_timeout = options.timeout.connect.not_nil! if options.timeout.connect
       conn.read_timeout = options.timeout.read.not_nil! if options.timeout.read
+      conn.write_timeout = options.timeout.write.not_nil! if options.timeout.write
       conn
     end
 

--- a/src/halite/options/timeout.cr
+++ b/src/halite/options/timeout.cr
@@ -4,10 +4,14 @@ module Halite
     struct Timeout
       getter connect : Float64?
       getter read : Float64?
+      getter write : Float64?
 
-      def initialize(connect : (Int32 | Float64 | Time::Span)? = nil, read : (Int32 | Float64 | Time::Span)? = nil)
+      def initialize(connect : (Int32 | Float64 | Time::Span)? = nil,
+                     read : (Int32 | Float64 | Time::Span)? = nil,
+                     write : (Int32 | Float64 | Time::Span)? = nil)
         @connect = timeout_value(connect)
         @read = timeout_value(read)
+        @write = timeout_value(write)
       end
 
       def connect=(connect : (Int32 | Float64 | Time::Span)?)
@@ -16,6 +20,10 @@ module Halite
 
       def read=(read : (Int32 | Float64 | Time::Span)?)
         @read = timeout_value(read)
+      end
+
+      def write=(write : (Int32 | Float64 | Time::Span)?)
+        @write = timeout_value(write)
       end
 
       private def timeout_value(value : (Int32 | Float64 | Time::Span)? = nil) : Float64?

--- a/src/halite/response.cr
+++ b/src/halite/response.cr
@@ -82,6 +82,7 @@ module Halite
         raise Halite::UnRegisterMimeTypeError.new("unregister MIME type adapter: #{name}") unless MimeType[name]?
         MimeType[name].decode to_s
       rescue MIME::Error
+        # NOTE: This catch could be remove in Crystal 0.32: https://github.com/crystal-lang/crystal/pull/8464
         raise Halite::Error.new("Missing media type")
       end
     end


### PR DESCRIPTION
As Crystal released v0.32(crystal-lang/crystal#8507) , Halite can use `write_timeout`:

```Crystal
Halite.timeout(write: 10).get "https://httpbin.org/get"
```

Even pass `nil` to ignore timeout setting.