### PR TITLE
Update to Crystal 0.34.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  test_crystal_0_33:
+  test_crystal_0_34:
     docker:
-      - image: "crystallang/crystal:0.33.0"
+      - image: "crystallang/crystal:0.34.0"
     environment:
       DOCS_PATH: "docs"
       GIT_USER: "icyleaf"
@@ -22,7 +22,7 @@ jobs:
       - deploy:
           name: "API documents"
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ] && [ ! "${CIRCLE_PR_NUMBER}" ]; then
+            if [[ "${CIRCLE_BRANCH}" == "master" ]] && [[ ! "${CIRCLE_PR_NUMBER}" ]]; then
               echo "Generate API documents"
               ./.circleci/generate_docs.sh
               echo "Upload API documents"
@@ -32,7 +32,7 @@ workflows:
   version: 2
   build_test_deploy:
     jobs:
-      - test_crystal_0_33:
+      - test_crystal_0_34:
           filters:
             branches:
               ignore:

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.10.4
 authors:
   - icyleaf <icyleaf.cn@gmail.com>
 
-crystal: 0.33.0
+crystal: 0.34.0
 
 license: MIT

--- a/src/halite/client.cr
+++ b/src/halite/client.cr
@@ -157,9 +157,9 @@ module Halite
       conn = make_connection(request, options)
       conn_response = conn.exec(request.verb, request.full_path, request.headers, request.body)
       handle_response(request, conn_response, options)
-    rescue ex : IO::Timeout
+    rescue ex : IO::TimeoutError
       raise TimeoutError.new(ex.message)
-    rescue ex : Socket::Error | Errno
+    rescue ex : Socket::Error
       raise ConnectionError.new(ex.message)
     end
 


### PR DESCRIPTION
- Changed `Timeout` to `TimeoutError`
- Removed `Errno`

This library was a dependency for another framework I was using (Tourmaline), these are the changes I made to make the code compile and run. That being said, there might be circumstances where errors were caught previously and they aren't anymore (due to the removal of Errno).

If that part was important, we can still import it from `SystemError` (they moved it), but it's strongly discouraged.

More information about this release, detailing the exception hierarchy changes a bit further down on the page: https://crystal-lang.org/2020/04/06/crystal-0.34.0-released.html