### PR TITLE
Resolve path of endpoint ending without slash

### DIFF
--- a/spec/halite/client_spec.cr
+++ b/spec/halite/client_spec.cr
@@ -54,13 +54,19 @@ describe Halite::Client do
       response.status_code.should eq(200)
     end
 
-    it "should always overwrite the path of uri if path starts with '/' char" do
+    it "should not overwrite the path of uri if path is empty string" do
       client = Halite::Client.new do
         endpoint "#{SERVER.endpoint}/redirect-301"
       end
 
       response = client.get("")
       response.status_code.should eq(301)
+    end
+
+    it "should always overwrite the path of uri if path starts with '/' char" do
+      client = Halite::Client.new do
+        endpoint "#{SERVER.endpoint}/redirect-301"
+      end
 
       response = client.accept("application/json").get("/")
       response.status_code.should eq(200)

--- a/spec/halite/features/cache_spec.cr
+++ b/spec/halite/features/cache_spec.cr
@@ -78,7 +78,7 @@ describe Halite::Cache do
   describe "intercept" do
     it "should cache to local storage" do
       body = {name: "foo"}.to_json
-      request = Halite::Request.new("get", SERVER.api("/anything?q=halite1#result"), HTTP::Headers{"Accept" => "application/json"})
+      request = Halite::Request.new("get", URI.parse(SERVER.api("/anything?q=halite1#result")), HTTP::Headers{"Accept" => "application/json"})
       response = Halite::Response.new(request.uri, 200, body, HTTP::Headers{"Content-Type" => "application/json", "Content-Length" => body.size.to_s})
       feature = Halite::Cache.new
       feature.file.should be_nil
@@ -114,7 +114,7 @@ describe Halite::Cache do
 
     it "should cache without debug mode" do
       body = {name: "foo1"}.to_json
-      request = Halite::Request.new("get", SERVER.api("/anything?q=halite2#result"), HTTP::Headers{"Accept" => "application/json"})
+      request = Halite::Request.new("get", URI.parse(SERVER.api("/anything?q=halite2#result")), HTTP::Headers{"Accept" => "application/json"})
       response = Halite::Response.new(request.uri, 200, body, HTTP::Headers{"Content-Type" => "application/json", "Content-Length" => body.size.to_s})
       feature = Halite::Cache.new(debug: false)
       feature.file.should be_nil
@@ -138,7 +138,7 @@ describe Halite::Cache do
 
     it "should return no cache if expired" do
       body = {name: "foo2"}.to_json
-      request = Halite::Request.new("get", SERVER.api("/anything?q=halite3#result"), HTTP::Headers{"Accept" => "application/json"})
+      request = Halite::Request.new("get", URI.parse(SERVER.api("/anything?q=halite3#result")), HTTP::Headers{"Accept" => "application/json"})
       response = Halite::Response.new(request.uri, 200, body, HTTP::Headers{"Content-Type" => "application/json", "Content-Length" => body.size.to_s})
       feature = Halite::Cache.new(expires: 1.milliseconds)
       feature.file.should be_nil
@@ -164,7 +164,7 @@ describe Halite::Cache do
     it "should load cache from file" do
       file = fixture_path("cache_file.json")
       body = load_fixture("cache_file.json")
-      request = Halite::Request.new("get", SERVER.api("/anything?q=halite4#result"), HTTP::Headers{"Accept" => "application/json"})
+      request = Halite::Request.new("get", URI.parse(SERVER.api("/anything?q=halite4#result")), HTTP::Headers{"Accept" => "application/json"})
       response = Halite::Response.new(request.uri, 200, body, HTTP::Headers{"Content-Type" => "application/json", "Content-Length" => body.size.to_s})
       feature = Halite::Cache.new(file: file)
       feature.file.should eq(file)

--- a/spec/halite/redirector_spec.cr
+++ b/spec/halite/redirector_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 private def request
-  Halite::Request.new("head", "http://example.com/foo?bar=baz")
+  Halite::Request.new("head", URI.parse("http://example.com/foo?bar=baz"))
 end
 
 def response(uri : URI, status_code = 200, headers = {} of String => String, body = "")
@@ -84,7 +84,7 @@ describe Halite::Redirector do
     context "following 300/301/302 redirect" do
       context "with strict mode" do
         it "it follows with original verb if it's safe" do
-          req = Halite::Request.new "get", "http://example.com/foo?bar=baz"
+          req = Halite::Request.new "get", URI.parse("http://example.com/foo?bar=baz")
           res = redirect_response 300, "http://example.com/1"
 
           redirector(req, res, true).perform do |prev_req|
@@ -94,7 +94,7 @@ describe Halite::Redirector do
         end
 
         it "raises StateError if original request was PUT" do
-          req = Halite::Request.new "put", "http://example.com/foo?bar=baz"
+          req = Halite::Request.new "put", URI.parse("http://example.com/foo?bar=baz")
           res = redirect_response 300, "http://example.com/1"
           expect_raises Halite::StateError do
             redirector(req, res, true).perform { |_| simple_response 200 }
@@ -102,7 +102,7 @@ describe Halite::Redirector do
         end
 
         it "raises StateError if original request was POST" do
-          req = Halite::Request.new "post", "http://example.com/foo?bar=baz"
+          req = Halite::Request.new "post", URI.parse("http://example.com/foo?bar=baz")
           res = redirect_response 301, "http://example.com/1"
           expect_raises Halite::StateError do
             redirector(req, res, true).perform { |_| simple_response 200 }
@@ -110,7 +110,7 @@ describe Halite::Redirector do
         end
 
         it "raises StateError if original request was DELETE" do
-          req = Halite::Request.new "delete", "http://example.com/foo?bar=baz"
+          req = Halite::Request.new "delete", URI.parse("http://example.com/foo?bar=baz")
           res = redirect_response 302, "http://example.com/1"
           expect_raises Halite::StateError do
             redirector(req, res, true).perform { |_| simple_response 200 }
@@ -120,7 +120,7 @@ describe Halite::Redirector do
 
       context "without strict mode" do
         it "it follows with original verb if it's safe" do
-          req = Halite::Request.new "get", "http://example.com/foo?bar=baz"
+          req = Halite::Request.new "get", URI.parse("http://example.com/foo?bar=baz")
           res = redirect_response 300, "http://example.com/1"
 
           redirector(req, res, false).perform do |prev_req|
@@ -130,7 +130,7 @@ describe Halite::Redirector do
         end
 
         it "raises StateError if original request was PUT" do
-          req = Halite::Request.new "put", "http://example.com/foo?bar=baz"
+          req = Halite::Request.new "put", URI.parse("http://example.com/foo?bar=baz")
           res = redirect_response 300, "http://example.com/1"
           redirector(req, res, false).perform do |prev_req|
             prev_req.verb.should eq "GET"
@@ -139,7 +139,7 @@ describe Halite::Redirector do
         end
 
         it "raises StateError if original request was POST" do
-          req = Halite::Request.new "post", "http://example.com/foo?bar=baz"
+          req = Halite::Request.new "post", URI.parse("http://example.com/foo?bar=baz")
           res = redirect_response 301, "http://example.com/1"
           redirector(req, res, false).perform do |prev_req|
             prev_req.verb.should eq "GET"
@@ -148,7 +148,7 @@ describe Halite::Redirector do
         end
 
         it "raises StateError if original request was DELETE" do
-          req = Halite::Request.new "delete", "http://example.com/foo?bar=baz"
+          req = Halite::Request.new "delete", URI.parse("http://example.com/foo?bar=baz")
           res = redirect_response 302, "http://example.com/1"
           redirector(req, res, false).perform do |prev_req|
             prev_req.verb.should eq "GET"
@@ -160,7 +160,7 @@ describe Halite::Redirector do
 
     context "following 303 redirect" do
       it "follows with HEAD if original request was HEAD" do
-        req = Halite::Request.new "head", "http://example.com/foo?bar=baz"
+        req = Halite::Request.new "head", URI.parse("http://example.com/foo?bar=baz")
         res = redirect_response 303, "http://example.com/1"
 
         redirector(req, res).perform do |prev_req|
@@ -170,7 +170,7 @@ describe Halite::Redirector do
       end
 
       it "follows with GET if original request was GET" do
-        req = Halite::Request.new "get", "http://example.com/foo?bar=baz"
+        req = Halite::Request.new "get", URI.parse("http://example.com/foo?bar=baz")
         res = redirect_response 303, "http://example.com/1"
 
         redirector(req, res).perform do |prev_req|
@@ -180,7 +180,7 @@ describe Halite::Redirector do
       end
 
       it "follows with GET if original request was neither GET nor HEAD" do
-        req = Halite::Request.new "post", "http://example.com/foo?bar=baz"
+        req = Halite::Request.new "post", URI.parse("http://example.com/foo?bar=baz")
         res = redirect_response 303, "http://example.com/1"
 
         redirector(req, res).perform do |prev_req|
@@ -192,7 +192,7 @@ describe Halite::Redirector do
 
     context "following 307 redirect" do
       it "follows with original request's verb" do
-        req = Halite::Request.new "post", "http://example.com/foo?bar=baz"
+        req = Halite::Request.new "post", URI.parse("http://example.com/foo?bar=baz")
         res = redirect_response 307, "http://example.com/1"
 
         redirector(req, res).perform do |prev_req|
@@ -204,7 +204,7 @@ describe Halite::Redirector do
 
     context "following 308 redirect" do
       it "follows with original request's verb" do
-        req = Halite::Request.new "post", "http://example.com/foo?bar=baz"
+        req = Halite::Request.new "post", URI.parse("http://example.com/foo?bar=baz")
         res = redirect_response 308, "http://example.com/1"
 
         redirector(req, res).perform do |prev_req|

--- a/spec/halite/request_spec.cr
+++ b/spec/halite/request_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 private def request
   Halite::Request.new(
     "get",
-    "http://example.com/foo/bar?q=halite#result",
+    URI.parse("http://example.com/foo/bar?q=halite#result"),
     HTTP::Headers{"Accept" => "text/html"},
   )
 end
@@ -39,7 +39,7 @@ describe Halite::Request do
 
     context "when subdomain and path are the same" do
       it "return `URI` with the scheme, user, password, port and host combined" do
-        Halite::Request.new("get", "https://login.example.com/login").domain.to_s.should eq "https://login.example.com"
+        Halite::Request.new("get", URI.parse("https://login.example.com/login")).domain.to_s.should eq "https://login.example.com"
       end
     end
   end
@@ -58,7 +58,7 @@ describe Halite::Request do
 
   describe "#redirect" do
     it "should return a new request" do
-      request = Halite::Request.new("GET", "http://httpbin.com/redirect/3", headers: HTTP::Headers{"Host" => "httpbin.com"})
+      request = Halite::Request.new("GET", URI.parse("http://httpbin.com/redirect/3"), headers: HTTP::Headers{"Host" => "httpbin.com"})
       new_request = request.redirect("http://httpbin.com/redirect/2")
       new_request.uri.to_s.should eq("http://httpbin.com/redirect/2")
       new_request.headers.has_key?("Host").should be_false
@@ -69,7 +69,7 @@ describe Halite::Request do
     end
 
     it "should return a new request without Host" do
-      request = Halite::Request.new("POST", "http://httpbin.com/redirect/3")
+      request = Halite::Request.new("POST", URI.parse("http://httpbin.com/redirect/3"))
       new_request = request.redirect("http://httpbin.com/redirect/2", "GET")
       new_request.uri.to_s.should eq("http://httpbin.com/redirect/2")
       new_request.verb.should eq("GET")
@@ -83,19 +83,19 @@ describe Halite::Request do
   describe "raises" do
     it "should throws an exception with not allowed request method" do
       expect_raises Halite::UnsupportedMethodError, "Unknown method: TRACE" do
-        Halite::Request.new("trace", "http://httpbin.org/get")
+        Halite::Request.new("trace", URI.parse("http://httpbin.org/get"))
       end
     end
 
     it "should throws an exception without scheme part of URI" do
       expect_raises Halite::UnsupportedSchemeError, "Missing scheme: example.com" do
-        Halite::Request.new("get", "example.com")
+        Halite::Request.new("get", URI.parse("example.com"))
       end
     end
 
     it "should throws an exception with not allowed scheme part of URI" do
       expect_raises Halite::UnsupportedSchemeError, "Unknown scheme: ws" do
-        Halite::Request.new("get", "ws://example.com")
+        Halite::Request.new("get", URI.parse("ws://example.com"))
       end
     end
   end

--- a/src/halite/client.cr
+++ b/src/halite/client.cr
@@ -199,19 +199,14 @@ module Halite
     end
 
     # Merges query params if needed
-    private def make_request_uri(url : String, options : Halite::Options) : String
-      uri = if endpoint = options.endpoint
-              endpoint.resolve(url)
-            else
-              URI.parse(url)
-            end
-
+    private def make_request_uri(url : String, options : Halite::Options) : URI
+      uri = resolve_uri(url, options)
       if params = options.params
         query = HTTP::Params.encode(params)
-        uri.query = [uri.query, query].compact.join("&") unless query.empty?
+        uri.query = [uri.query, query].compact.join('&') unless query.empty?
       end
 
-      uri.to_s
+      uri
     end
 
     # Merges request headers
@@ -279,6 +274,14 @@ module Halite
     private def branch(options : Halite::Options? = nil) : Halite::Client
       oneshot_options.merge!(options)
       self
+    end
+
+    private def resolve_uri(url : String, options : Halite::Options) : URI
+      return URI.parse(url) unless endpoint = options.endpoint
+      return endpoint if url.empty?
+
+      endpoint.path += '/' unless endpoint.path.ends_with?('/')
+      endpoint.resolve(url)
     end
 
     # :nodoc:

--- a/src/halite/request.cr
+++ b/src/halite/request.cr
@@ -26,9 +26,8 @@ module Halite
     # The payload of request
     getter body : String
 
-    def initialize(verb : String, uri : String, @headers : HTTP::Headers = HTTP::Headers.new, @body : String = "")
+    def initialize(verb : String, @uri : URI, @headers : HTTP::Headers = HTTP::Headers.new, @body : String = "")
       @verb = verb.upcase
-      @uri = normalize_uri(uri)
 
       raise UnsupportedMethodError.new("Unknown method: #{@verb}") unless METHODS.includes?(@verb)
       raise UnsupportedSchemeError.new("Missing scheme: #{@uri}") unless @uri.scheme
@@ -64,13 +63,8 @@ module Halite
       end
     end
 
-    # @return `URI` with all components but query being normalized.
-    private def normalize_uri(uri : String) : URI
-      URI.parse(uri)
-    end
-
-    private def redirect_uri(source : URI, uri : String) : String
-      return source.to_s if uri == '/'
+    private def redirect_uri(source : URI, uri : String) : URI
+      return source if uri == '/'
 
       new_uri = URI.parse(uri)
       # return a new uri with source and relative path
@@ -80,7 +74,7 @@ module Halite
         end
       end
 
-      new_uri.to_s
+      new_uri
     end
 
     # Request data of body


### PR DESCRIPTION
Relates #93 

- Fix ending slash issue
- Refactor `Halite::Request` initialize only accept `URI` as url argument. (reduce memory costs)