### PR TITLE
Drop custom file logging in favor of Crystal's centralized config

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal: [ '0.34.0', '0.35.0', '0.35.1', '0.36.0', 'latest', 'nightly' ]
+        crystal: [ '0.35.0', '0.35.1', '0.36.0', 'latest', 'nightly' ]
     name: Crystal ${{ matrix.crystal }} tests
     steps:
     - uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ HTTP Requests with a chainable REST API, built-in sessions and middleware writte
 Inspired from the **awesome** Ruby's [HTTP](https://github.com/httprb/http)/[RESTClient](https://github.com/rest-client/rest-client)
 and Python's [requests](https://github.com/requests/requests).
 
-Build in Crystal version >= `v0.34.0`, this document valid with latest commit.
+Build in Crystal version `>= 0.35.0`, this document valid with latest commit.
 
 ## Index
 

--- a/README.md
+++ b/README.md
@@ -742,12 +742,17 @@ Halite.logging(format: "json")
 
 ```crystal
 # Write plain text to a log file
-Halite.logging(file: "logs/halite.log", skip_benchmark: true, colorize: false)
+Log.setup("halite.file", backend: Log::IOBackend.new(File.open("/tmp/halite.log", "a")))
+Halite.logging(for: "halite.file", skip_benchmark: true, colorize: false)
       .get("http://httpbin.org/get", params: {name: "foobar"})
 
 # Write json data to a log file
-Halite.logging(format: "json", file: "logs/halite.log")
+Log.setup("halite.file", backend: Log::IOBackend.new(File.open("/tmp/halite.log", "a")))
+Halite.logging(format: "json", for: "halite.file")
       .get("http://httpbin.org/get", params: {name: "foobar"})
+
+# Redirect *all* logging from Halite to a file:
+Log.setup("halite", backend: Log::IOBackend.new(File.open("/tmp/halite.log", "a")))
 ```
 
 #### Use the custom logging

--- a/spec/halite/features/logging_spec.cr
+++ b/spec/halite/features/logging_spec.cr
@@ -39,7 +39,8 @@ describe Halite::Logging do
     it "should use File IO" do
       with_tempfile("halite-features-logging") do |file|
         uri = URI.parse("https://httpbin.org/get")
-        writer = Halite::Logging::Common.new(file: file)
+        Log.setup("halite.spec.file", backend: Log::IOBackend.new(File.open(file, "w")))
+        writer = Halite::Logging::Common.new(for: "halite.spec.file")
         logging = Halite::Logging.new(logging: writer)
         logging.writer.should be_a(Halite::Logging::Common)
         logging.request(Halite::Request.new("get", uri))

--- a/spec/halite/options_spec.cr
+++ b/spec/halite/options_spec.cr
@@ -468,7 +468,8 @@ describe Halite::Options do
       Halite::Logging.register "simple", SimpleLogger
 
       with_tempfile("halite_logger") do |file|
-        options = Halite::Options.new.with_logging(format: "simple", file: file, filemode: "w")
+        Log.setup("halite.tempfile", backend: Log::IOBackend.new(File.open("/tmp/halite.log", "w")))
+        options = Halite::Options.new.with_logging(format: "simple")
         logging = options.features["logging"].as(Halite::Logging)
         logging.writer.should be_a(SimpleLogger)
       end

--- a/spec/halite_spec.cr
+++ b/spec/halite_spec.cr
@@ -541,7 +541,8 @@ describe Halite do
 
     it "sets logging into file" do
       with_tempfile("halite-spec-logging") do |file|
-        client = Halite.logging(file: file, skip_response_body: true)
+        Log.setup("halite.spec.file", backend: Log::IOBackend.new(File.open(file, "a")))
+        client = Halite.logging(for: "halite.spec.file", skip_response_body: true)
         client.options.features.has_key?("logging").should be_true
         client.options.features["logging"].should be_a(Halite::Logging)
         logging = client.options.features["logging"].as(Halite::Logging)

--- a/src/halite/chainable.cr
+++ b/src/halite/chainable.cr
@@ -369,24 +369,25 @@ module Halite
     # #### create a http request and log to file
     #
     # ```
-    # Halite.logging(file: "/tmp/halite.log")
+    # Log.setup("halite.file", backend: Log::IOBackend.new(File.open("/tmp/halite.log", "a")))
+    # Halite.logging(for: "halite.file")
     #   .get("http://httpbin.org/get", params: {name: "foobar"})
     # ```
     #
     # #### Always create new log file and store data to JSON formatted
     #
     # ```
-    # Halite.logging(format: "json", file: "/tmp/halite.log")
+    # Log.setup("halite.file", backend: Log::IOBackend.new(File.open("/tmp/halite.log", "w"))
+    # Halite.logging(for: "halite.file", format: "json")
     #   .get("http://httpbin.org/get", params: {name: "foobar"})
     # ```
     #
     # Check the log file content: **/tmp/halite.log**
-    def logging(format : String = "common", file : String? = nil, filemode = "a",
+    def logging(format : String = "common", *, for : String = "halite",
                 skip_request_body = false, skip_response_body = false,
                 skip_benchmark = false, colorize = true)
       opts = {
-        file:               file,
-        filemode:           filemode,
+        for:                for,
         skip_request_body:  skip_request_body,
         skip_response_body: skip_response_body,
         skip_benchmark:     skip_benchmark,

--- a/src/halite/features/logging.cr
+++ b/src/halite/features/logging.cr
@@ -32,11 +32,6 @@ module Halite
 
     # Logging format Abstract
     abstract class Abstract
-      def self.new(*, for : String = "halite", skip_request_body = false, skip_response_body = false,
-                   skip_benchmark = false, colorize = true)
-        new(skip_request_body, skip_response_body, skip_benchmark, colorize)
-      end
-
       setter logger : Log
       getter skip_request_body : Bool
       getter skip_response_body : Bool
@@ -45,7 +40,8 @@ module Halite
 
       @request_time : Time?
 
-      def initialize(for : String = "halite", @skip_request_body = false, @skip_response_body = false,
+      def initialize(*, for : String = "halite",
+                     @skip_request_body = false, @skip_response_body = false,
                      @skip_benchmark = false, @colorize = true)
         @logger = Log.for(for)
         Colorize.enabled = @colorize

--- a/src/halite/features/logging.cr
+++ b/src/halite/features/logging.cr
@@ -2,6 +2,8 @@ require "log"
 require "colorize"
 require "file_utils"
 
+Log.setup("halite")
+
 module Halite
   # Logging feature
   class Logging < Feature
@@ -30,20 +32,9 @@ module Halite
 
     # Logging format Abstract
     abstract class Abstract
-      def self.new(file : String? = nil, filemode = "a",
-                   skip_request_body = false, skip_response_body = false,
+      def self.new(*, for : String = "halite", skip_request_body = false, skip_response_body = false,
                    skip_benchmark = false, colorize = true)
-        io = if file
-               file = File.expand_path(file)
-               filepath = File.dirname(file)
-               FileUtils.mkdir_p(filepath) unless Dir.exists?(filepath)
-
-               File.new(file, filemode)
-             else
-               STDOUT
-             end
-
-        new(skip_request_body, skip_response_body, skip_benchmark, colorize, io)
+        new(skip_request_body, skip_response_body, skip_benchmark, colorize)
       end
 
       setter logger : Log
@@ -54,22 +45,14 @@ module Halite
 
       @request_time : Time?
 
-      def initialize(@skip_request_body = false, @skip_response_body = false,
-                     @skip_benchmark = false, @colorize = true, @io : IO = STDOUT)
-        backend = Log::IOBackend.new(@io)
-        backend.formatter = default_formatter
-        @logger = Log.new("halite", backend, :debug)
+      def initialize(for : String = "halite", @skip_request_body = false, @skip_response_body = false,
+                     @skip_benchmark = false, @colorize = true)
+        @logger = Log.for(for)
         Colorize.enabled = @colorize
       end
 
       abstract def request(request)
       abstract def response(response)
-
-      protected def default_formatter
-        Log::Formatter.new do |entry, io|
-          io << entry.message
-        end
-      end
 
       protected def human_time(elapsed : Time::Span)
         elapsed = elapsed.to_f

--- a/src/halite/features/logging/common.cr
+++ b/src/halite/features/logging/common.cr
@@ -84,6 +84,8 @@ class Halite::Logging
     end
 
     protected def colorful(message, fore, back)
+      Colorize.enabled = @colorize && !!(backend = @logger.backend.as?(Log::IOBackend)) && backend.io.tty?
+
       message.colorize.fore(fore).back(back)
     end
 

--- a/src/halite/features/logging/common.cr
+++ b/src/halite/features/logging/common.cr
@@ -84,7 +84,7 @@ class Halite::Logging
     end
 
     protected def colorful(message, fore, back)
-      Colorize.enabled = @colorize && !!(backend = @logger.backend.as?(Log::IOBackend)) && backend.io.tty?
+      Colorize.enabled = !!(@colorize && (backend = @logger.backend.as?(Log::IOBackend)) && backend.io.tty?)
 
       message.colorize.fore(fore).back(back)
     end

--- a/src/halite/features/logging/common.cr
+++ b/src/halite/features/logging/common.cr
@@ -84,8 +84,6 @@ class Halite::Logging
     end
 
     protected def colorful(message, fore, back)
-      Colorize.enabled = !@io.is_a?(File) && @colorize
-
       message.colorize.fore(fore).back(back)
     end
 


### PR DESCRIPTION
I found that it's impossible to affect Halite's config through Crystal's centralized config.

That is, if I run:

`Log.setup_from_env`

Then I have the ability to hide most logs by adding `LOG_LEVEL=ERROR` environment. But Halite's logs are not affected by this.

Then I also noticed that it has its own custom file handling. But why should the user deal with several different redirect mechanisms when they, for example, want to redirect all logs to a file? In that situation Halite will also be the only one refusing to cooperate.

So I show you an idea of how the specific configs can be dropped from Halite's code base. It's a breaking change, though.

And there is a new problem: `Colorize` can no longer detect that it's being written to a file. But I think users can disable colorize themselves in a practical way if they know they'll be writing to a file.